### PR TITLE
feat: fastlane ci action

### DIFF
--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -35,8 +35,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Setup ruby on github hosted machines, step fails on self-hosted macjenkins
     - name: Setup ruby
-      # Step fails on self-hosted macjenkins
       if: ${{ runner.name == 'Hosted Agent' }}
       uses: ruby/setup-ruby@v1
       with:
@@ -47,21 +47,21 @@ runs:
       with:
         distribution: ${{ inputs.java_distribution }}
         java-version: ${{ inputs.java_version }}
+    # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
-      # Setup dependencies for fastlane package from Gemfile
       shell: bash
       run: |
         gem install bundler:${{ inputs.bundler_version }}
         bundle install --jobs 4 --retry 3
+    # "Provision keystore for sign from github secret and replace env vars with new values, see more: https://developer.android.com/training/articles/keystore"
     - name: Provision ci keystore for Android
-      # "Provision keystore for sign from github secret and replace env vars with new values, see more: https://developer.android.com/training/articles/keystore"
       if: ${{ inputs.keystore != '' }}
       shell: bash
       run: |
         echo "${{ inputs.keystore }}" | base64 --decode > fastlane/release.keystore
         echo "RELEASE_KEYSTORE_PATH=release.keystore" >> $GITHUB_ENV
         echo "RELEASE_KEYSTORE_PASS=${{ inputs.keystore_pass }}" >> $GITHUB_ENV
+    # Execute lane from Fastfile
     - name: Execute fastlane target
-      # Execute lane from Fastfile
       shell: bash
       run: bundle exec fastlane android ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -1,12 +1,9 @@
-name: 'fastlane'
-description: 'Runs fastlane with target'
+name: 'fastlane-android'
+description: 'Runs fastlane ci for android platform'
 inputs:
   environment:
     description: "According .env file provided in fastlane folder, usually one of [local, dev, staging, prod]"
     required: true
-  platform:
-    description: "Build platform declared in Fastfile, usually one of [android, ios]"
-    reauired: true
   target:
     description: "Build target declared in Fastfile, usually one of [build, release]"
     required: true
@@ -35,22 +32,17 @@ inputs:
     description: Option of action/setup-java@v2
     required: false
     default: '11'
-  # iOS
-  certificate:
-    description: "Certificate for ios sign"
-    required: false
-    default: ""
 runs:
   using: "composite"
   steps:
     - name: Setup ruby
+      # Step fails on self-hosted macjenkins
       if: ${{ runner.name == 'Hosted Agent' }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
     - name: Setup java
-      if: ${{ inputs.platform == 'android' }}
       uses: actions/setup-java@v2
       with:
         distribution: ${{ inputs.java_distribution }}
@@ -61,16 +53,9 @@ runs:
       run: |
         gem install bundler:${{ inputs.bundler_version }}
         bundle install --jobs 4 --retry 3
-    - name: Update ci keychain for iOS
-      # "Populates 'ci' keychain with provided external cert for code sign, see more: https://blog.codemagic.io/how-to-code-sign-publish-ios-apps/"
-      if: ${{ inputs.platform == 'ios' && inputs.certificate != ''}}
-      shell: bash
-      run: |
-        echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.certificate
-        bundle exec fastlane ios update_keychain
     - name: Provision ci keystore for Android
       # "Provision keystore for sign from github secret and replace env vars with new values, see more: https://developer.android.com/training/articles/keystore"
-      if: ${{ inputs.platform == 'android' && inputs.keystore != '' }}
+      if: ${{ inputs.keystore != '' }}
       shell: bash
       run: |
         echo "${{ inputs.keystore }}" | base64 --decode > fastlane/release.keystore
@@ -79,4 +64,4 @@ runs:
     - name: Execute fastlane target
       # Execute lane from Fastfile
       shell: bash
-      run: bundle exec fastlane ${{ inputs.platform }} ${{ inputs.target }} --env ${{ inputs.environment }}
+      run: bundle exec fastlane android ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane-ios/action.yaml
+++ b/.github/actions/fastlane-ios/action.yaml
@@ -23,27 +23,27 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Setup ruby on github hosted machines, step fails on self-hosted macjenkins
     - name: Setup ruby
-      # Step fails on self-hosted macjenkins
       if: ${{ runner.name == 'Hosted Agent' }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
+    # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
-      # Setup dependencies for fastlane package from Gemfile
       shell: bash
       run: |
         gem install bundler:${{ inputs.bundler_version }}
         bundle install --jobs 4 --retry 3
+    # "Populates 'ci' keychain with provided external cert for code sign, see more: https://blog.codemagic.io/how-to-code-sign-publish-ios-apps/"
     - name: Update ci keychain for iOS
-      # "Populates 'ci' keychain with provided external cert for code sign, see more: https://blog.codemagic.io/how-to-code-sign-publish-ios-apps/"
       if: ${{ inputs.certificate != ''}}
       shell: bash
       run: |
         echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.certificate
         bundle exec fastlane ios update_keychain
+    # Execute lane from Fastfile
     - name: Execute fastlane target
-      # Execute lane from Fastfile
       shell: bash
       run: bundle exec fastlane ios ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane-ios/action.yaml
+++ b/.github/actions/fastlane-ios/action.yaml
@@ -41,7 +41,7 @@ runs:
       if: ${{ inputs.certificate != ''}}
       shell: bash
       run: |
-        echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.certificate
+        echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.p12
         bundle exec fastlane ios update_keychain
     # Execute lane from Fastfile
     - name: Execute fastlane target

--- a/.github/actions/fastlane-ios/action.yaml
+++ b/.github/actions/fastlane-ios/action.yaml
@@ -1,0 +1,49 @@
+name: 'fastlane'
+description: 'Runs fastlane ci for ios platformwith target'
+inputs:
+  environment:
+    description: "According .env file provided in fastlane folder, usually one of [local, dev, staging, prod]"
+    required: true
+  target:
+    description: "Build target declared in Fastfile, usually one of [build, release]"
+    required: true
+  # Optional
+  ruby_version:
+    required: false
+    default: '3.0'
+  bundler_version:
+    description: Option for 'gem install` command
+    required: false
+    default: '2.2.16'
+  # iOS
+  certificate:
+    description: "Certificate for ios sign"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Setup ruby
+      # Step fails on self-hosted macjenkins
+      if: ${{ runner.name == 'Hosted Agent' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ inputs.ruby_version }}
+        bundler-cache: true
+    - name: Setup dependencies
+      # Setup dependencies for fastlane package from Gemfile
+      shell: bash
+      run: |
+        gem install bundler:${{ inputs.bundler_version }}
+        bundle install --jobs 4 --retry 3
+    - name: Update ci keychain for iOS
+      # "Populates 'ci' keychain with provided external cert for code sign, see more: https://blog.codemagic.io/how-to-code-sign-publish-ios-apps/"
+      if: ${{ inputs.certificate != ''}}
+      shell: bash
+      run: |
+        echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.certificate
+        bundle exec fastlane ios update_keychain
+    - name: Execute fastlane target
+      # Execute lane from Fastfile
+      shell: bash
+      run: bundle exec fastlane ios ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane/action.yaml
+++ b/.github/actions/fastlane/action.yaml
@@ -2,57 +2,81 @@ name: 'fastlane'
 description: 'Runs fastlane with target'
 inputs:
   environment:
+    description: "According .env file provided in fastlane folder, usually one of [local, dev, staging, prod]"
     required: true
   platform:
+    description: "Build platform declared in Fastfile, usually one of [android, ios]"
     reauired: true
   target:
+    description: "Build target declared in Fastfile, usually one of [build, release]"
     required: true
-  P12:
-    description: "P12 cert for ios sign"
+  # Optional
+  ruby_version:
+    required: false
+    default: '3.0'
+  bundler_version:
+    description: Option for 'gem install` command
+    required: false
+    default: '2.2.16'
+  # Android
+  keystore:
+    description: "keystore for android sign"
     required: false
     default: ""
-  RELEASE_KEYSTORE:
-    description: "RELEASE_KEYSTORE for android sign"
+  keystore_pass: 
+    description: "Password for android keystore"
     required: false
     default: ""
-  RELEASE_KEYSTORE_PASS: 
-    description: "Password for android RELEASE_KEYSTORE"
+  java_distribution:
+    description: Option of action/setup-java@v2
+    required: false
+    default: 'adopt'
+  java_version:
+    description: Option of action/setup-java@v2
+    required: false
+    default: '11'
+  # iOS
+  certificate:
+    description: "Certificate for ios sign"
     required: false
     default: ""
 runs:
   using: "composite"
   steps:
-    - name: Set up ruby
+    - name: Setup ruby
       if: ${{ runner.name == 'Hosted Agent' }}
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
     - name: Setup java
       if: ${{ inputs.platform == 'android' }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: ${{ inputs.java_distribution }}
+        java-version: ${{ inputs.java_version }}
     - name: Setup dependencies
+      # Setup dependencies for fastlane package from Gemfile
       shell: bash
       run: |
-        gem install bundler:2.2.16
+        gem install bundler:${{ inputs.bundler_version }}
         bundle install --jobs 4 --retry 3
     - name: Update ci keychain for iOS
-      if: ${{ inputs.platform == 'ios' && inputs.P12 != ''}}
+      # "Populates 'ci' keychain with provided external cert for code sign, see more: https://blog.codemagic.io/how-to-code-sign-publish-ios-apps/"
+      if: ${{ inputs.platform == 'ios' && inputs.certificate != ''}}
       shell: bash
       run: |
-        echo -n "${{ inputs.P12 }}" | base64 --decode --output fastlane/cert.p12
+        echo -n "${{ inputs.certificate }}" | base64 --decode --output fastlane/cert.certificate
         bundle exec fastlane ios update_keychain
     - name: Provision ci keystore for Android
-      if: ${{ inputs.platform == 'android' && inputs.RELEASE_KEYSTORE != '' }}
+      # "Provision keystore for sign from github secret and replace env vars with new values, see more: https://developer.android.com/training/articles/keystore"
+      if: ${{ inputs.platform == 'android' && inputs.keystore != '' }}
       shell: bash
       run: |
-        echo "${{ inputs.RELEASE_KEYSTORE }}" | base64 --decode > fastlane/release.keystore
+        echo "${{ inputs.keystore }}" | base64 --decode > fastlane/release.keystore
         echo "RELEASE_KEYSTORE_PATH=release.keystore" >> $GITHUB_ENV
-        echo "RELEASE_KEYSTORE_PASS=${{ inputs.RELEASE_KEYSTORE_PASS }}" >> $GITHUB_ENV
+        echo "RELEASE_KEYSTORE_PASS=${{ inputs.keystore_pass }}" >> $GITHUB_ENV
     - name: Execute fastlane target
+      # Execute lane from Fastfile
       shell: bash
       run: bundle exec fastlane ${{ inputs.platform }} ${{ inputs.target }} --env ${{ inputs.environment }}
-

--- a/.github/actions/fastlane/action.yaml
+++ b/.github/actions/fastlane/action.yaml
@@ -1,0 +1,43 @@
+name: 'fastlane'
+description: 'Runs fastlane with target'
+inputs:
+  environment:
+    required: true
+  platform:
+    reauired: true
+  target:
+    required: true
+  P12:
+    description: "P12 cert for ios sign"
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Set up ruby
+      if: ${{ runner.name == 'Hosted Agent' }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+    - name: Setup java
+      if: ${{ inputs.platform == 'android' }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '11'
+    - name: Setup dependencies
+      shell: bash
+      run: |
+        gem install bundler:2.2.16
+        bundle install --jobs 4 --retry 3
+    - name: Update ci keychain for iOS
+      if: ${{ inputs.platform == 'ios' && inputs.P12 != ''}}
+      shell: bash
+      run: |
+        echo -n "${{ inputs.P12 }}" | base64 --decode --output fastlane/cert.p12
+        bundle exec fastlane ios update_keychain
+    - name: Execute fastlane target
+      shell: bash
+      run: bundle exec fastlane ${{ inputs.platform }} ${{ inputs.target }} --env ${{ inputs.environment }}
+

--- a/.github/actions/fastlane/action.yaml
+++ b/.github/actions/fastlane/action.yaml
@@ -11,6 +11,14 @@ inputs:
     description: "P12 cert for ios sign"
     required: false
     default: ""
+  RELEASE_KEYSTORE:
+    description: "RELEASE_KEYSTORE for android sign"
+    required: false
+    default: ""
+  RELEASE_KEYSTORE_PASS: 
+    description: "Password for android RELEASE_KEYSTORE"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -37,6 +45,13 @@ runs:
       run: |
         echo -n "${{ inputs.P12 }}" | base64 --decode --output fastlane/cert.p12
         bundle exec fastlane ios update_keychain
+    - name: Provision ci keystore for Android
+      if: ${{ inputs.platform == 'android' && inputs.RELEASE_KEYSTORE != '' }}
+      shell: bash
+      run: |
+        echo "${{ inputs.RELEASE_KEYSTORE }}" | base64 --decode > release.keystore
+        echo "RELEASE_KEYSTORE_PATH=release.keystore" >> $GITHUB_ENV
+        echo "RELEASE_KEYSTORE_PASS=${{ inputs.RELEASE_KEYSTORE_PASS }}" >> $GITHUB_ENV
     - name: Execute fastlane target
       shell: bash
       run: bundle exec fastlane ${{ inputs.platform }} ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane/action.yaml
+++ b/.github/actions/fastlane/action.yaml
@@ -49,7 +49,7 @@ runs:
       if: ${{ inputs.platform == 'android' && inputs.RELEASE_KEYSTORE != '' }}
       shell: bash
       run: |
-        echo "${{ inputs.RELEASE_KEYSTORE }}" | base64 --decode > release.keystore
+        echo "${{ inputs.RELEASE_KEYSTORE }}" | base64 --decode > fastlane/release.keystore
         echo "RELEASE_KEYSTORE_PATH=release.keystore" >> $GITHUB_ENV
         echo "RELEASE_KEYSTORE_PASS=${{ inputs.RELEASE_KEYSTORE_PASS }}" >> $GITHUB_ENV
     - name: Execute fastlane target


### PR DESCRIPTION
Prepares environment for ios/android builds on machine.
Executes fastlane via bundle with parametres: 
`fastlane platform target --env environment` like `fastline ios release --env dev`

Why not workflow?
- Action more flexible in situation where we need to prepare code (like ionic/cordova) or to make something with build result.
- Action stores no options or build steps, only prepare build environment.
- Fastlane can do mostly all kind of things that we need to do and with that action we split possible fastlane issues from github itself and can debug it locally ( `local` environment)
- No hardcoded or complicated staff, action only do exact job.

Here is repos PR's where i have used that action. 
Simple ci: 
https://github.com/saritasa-nest/toro-ios/pull/2
https://github.com/saritasa-nest/toro-android/pull/2
Or little more complicated:
https://github.com/saritasa-nest/core-source-frontend/pull/8