### PR TITLE
feat: add optional google_services_json parameter

### DIFF
--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -16,11 +16,15 @@ inputs:
     required: false
     default: '2.2.16'
   # Android
+  google_services_json:
+    description: google-services.json file content
+    required: false
+    default: ''
   keystore:
     description: "keystore for android sign"
     required: false
     default: ""
-  keystore_pass: 
+  keystore_pass:
     description: "Password for android keystore"
     required: false
     default: ""
@@ -61,6 +65,11 @@ runs:
         echo "${{ inputs.keystore }}" | base64 --decode > fastlane/release.keystore
         echo "RELEASE_KEYSTORE_PATH=release.keystore" >> $GITHUB_ENV
         echo "RELEASE_KEYSTORE_PASS=${{ inputs.keystore_pass }}" >> $GITHUB_ENV
+    - name: Provision goolge-services.json
+      if: ${{ inputs.google_services_json != '' }}
+      shell: bash
+      run: |
+        echo "${{ inputs.google_services_json }} > fastlane/google-services.json"
     # Execute lane from Fastfile
     - name: Execute fastlane target
       shell: bash


### PR DESCRIPTION
You can store `google-services.json` file in github secrets and inject it as follows:

```yaml
jobs:
  release-apk:
    runs-on: [self-hosted, macos, x64]
    steps:
      - uses: actions/checkout@v2
      - uses: saritasa-nest/saritasa-github-actions/.github/actions/fastlane-android@v2.2
        env:
          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
          SLACK_URL: ${{ secrets.SLACK_URL }}
          RELEASE_KEYSTORE_PASS: ${{ secrets.RELEASE_KEYSTORE_PASS }}
          RELEASE_KEY_PASS: ${{ secrets.RELEASE_KEYSTORE_PASS }}
        with:
          environment: dev
          target: release
          google_services_json: ${{ secrets.GOOGLE_SERVICES_JSON_DEV }}             <---- here
```
To 