### PR TITLE
feat: update fastlane-android

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #
 # For details see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*  @dmitry-mightydevops @DanilaKazakevich @kseniyashaydurova @MikhailKorol-saritasa @owlfog @populov @roman-mightydevops @SergeyDeminSaritasa
+*  @dmitry-mightydevops @DanilaKazakevich @kseniyashaydurova @MikhailKorol-saritasa @populov @roman-mightydevops @SergeyDeminSaritasa @udaltsovra @luciano-buono @KrawczowaKris @rtest12 @darliiin

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -37,14 +37,6 @@ inputs:
     description: Option of action/setup-java@v4
     required: false
     default: '11'
-  android_buildtools_version:
-    description: Version for build-tools package of android-actions/setup-android@v3
-    required: false
-    default: 34.0.0
-  android_platform_version:
-    description: Version for platform package of android-actions/setup-android@v3
-    required: false
-    default: 34
 runs:
   using: "composite"
   steps:
@@ -62,15 +54,14 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
-#      with:
-#        packages: tools platform-tools "build-tools;${{ inputs.android_buildtools_version }}" "android-${{ inputs.android_platform_version }}"
     # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
       shell: bash
       run: |
         gem install bundler:${{ inputs.bundler_version }}
         bundle install --jobs 4 --retry 3
-    # "Provision keystore for sign from github secret and replace env vars with new values, see more: https://developer.android.com/training/articles/keystore"
+    # "Provision keystore for sign from github secret and replace env vars with new values,
+    # see more: https://developer.android.com/training/articles/keystore"
     - name: Provision ci keystore for Android
       if: ${{ inputs.keystore != '' }}
       shell: bash

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -81,4 +81,3 @@ runs:
       env:
         LC_ALL: en_US.UTF-8
         LANG: en_US.UTF-8
-

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -29,25 +29,25 @@ inputs:
     required: false
     default: ""
   java_distribution:
-    description: Option of action/setup-java@v2
+    description: Option of action/setup-java@v4
     required: false
     default: 'adopt'
   java_version:
-    description: Option of action/setup-java@v2
+    description: Option of action/setup-java@v4
     required: false
     default: '11'
 runs:
   using: "composite"
   steps:
-    # Setup ruby on github hosted machines, step fails on self-hosted macjenkins
+    # Setup step fails on self-hosted macjenkins
     - name: Setup ruby
-      if: ${{ runner.name == 'Hosted Agent' }}
+      if: ${{ runner.name != 'macjenkins3-v2' && runner.name != 'macjenkins3-v3' }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby_version }}
         bundler-cache: true
     - name: Setup java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: ${{ inputs.java_distribution }}
         java-version: ${{ inputs.java_version }}
@@ -69,7 +69,7 @@ runs:
       if: ${{ inputs.google_services_json != '' }}
       shell: bash
       run: |
-        echo "${{ inputs.google_services_json }} > fastlane/google-services.json"
+        echo "${{ inputs.google_services_json }}" > fastlane/google-services.json
     # Execute lane from Fastfile
     - name: Execute fastlane target
       shell: bash

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -9,6 +9,7 @@ inputs:
     required: true
   # Optional
   ruby_version:
+    description: Version for ruby/setup-ruby@v1
     required: false
     default: '3.0'
   bundler_version:
@@ -36,6 +37,10 @@ inputs:
     description: Option of action/setup-java@v4
     required: false
     default: '11'
+  android_version:
+    description: Version for build-tools package of android-actions/setup-android@v3
+    required: false
+    default: 23.0.0
 runs:
   using: "composite"
   steps:
@@ -53,6 +58,8 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+      with:
+        packages: build-tools;${{ inputs.android_version }}
     # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
       shell: bash
@@ -79,5 +86,4 @@ runs:
       env:
         LC_ALL: en_US.UTF-8
         LANG: en_US.UTF-8
-        ANDROID_HOME: /home/runner/.android/sdk/
 

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -37,10 +37,14 @@ inputs:
     description: Option of action/setup-java@v4
     required: false
     default: '11'
-  android_version:
+  android_buildtools_version:
     description: Version for build-tools package of android-actions/setup-android@v3
     required: false
-    default: 23.0.0
+    default: 34.0.0
+  android_platform_version:
+    description: Version for platform package of android-actions/setup-android@v3
+    required: false
+    default: 34
 runs:
   using: "composite"
   steps:
@@ -59,7 +63,7 @@ runs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
       with:
-        packages: build-tools;${{ inputs.android_version }}
+        packages: tools platform-tools "build-tools;${{ inputs.android_buildtools_version }}" "platform;${{ inputs.android_platform_version }}"
     # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
       shell: bash

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -73,10 +73,14 @@ runs:
       run: |
         echo "${{ inputs.google_services_json }}" > fastlane/google-services.json
     # Execute lane from Fastfile
+    - name: android SDK tree
+      shell: bash
+      run: tree -L 3 /home/runner/.android/
     - name: Execute fastlane target
       shell: bash
       run: bundle exec fastlane android ${{ inputs.target }} --env ${{ inputs.environment }}
       env:
         LC_ALL: en_US.UTF-8
         LANG: en_US.UTF-8
+        ANDROID_HOME: /home/runner/.android/sdk/
 

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -41,7 +41,7 @@ runs:
   steps:
     # Setup step fails on self-hosted macjenkins
     - name: Setup ruby
-      if: ${{ runner.name != 'macjenkins3-v2' && runner.name != 'macjenkins3-v3' }}
+      if: ${{ runner.platform != 'darwin' }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby_version }}
@@ -51,6 +51,8 @@ runs:
       with:
         distribution: ${{ inputs.java_distribution }}
         java-version: ${{ inputs.java_version }}
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
     # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
       shell: bash
@@ -74,3 +76,7 @@ runs:
     - name: Execute fastlane target
       shell: bash
       run: bundle exec fastlane android ${{ inputs.target }} --env ${{ inputs.environment }}
+      env:
+        LC_ALL: en_US.UTF-8
+        LANG: en_US.UTF-8
+

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -73,9 +73,6 @@ runs:
       run: |
         echo "${{ inputs.google_services_json }}" > fastlane/google-services.json
     # Execute lane from Fastfile
-    - name: android SDK tree
-      shell: bash
-      run: tree -L 3 /home/runner/.android/
     - name: Execute fastlane target
       shell: bash
       run: bundle exec fastlane android ${{ inputs.target }} --env ${{ inputs.environment }}

--- a/.github/actions/fastlane-android/action.yaml
+++ b/.github/actions/fastlane-android/action.yaml
@@ -62,8 +62,8 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
-      with:
-        packages: tools platform-tools "build-tools;${{ inputs.android_buildtools_version }}" "platform;${{ inputs.android_platform_version }}"
+#      with:
+#        packages: tools platform-tools "build-tools;${{ inputs.android_buildtools_version }}" "android-${{ inputs.android_platform_version }}"
     # Setup dependencies for fastlane package from Gemfile
     - name: Setup dependencies
       shell: bash

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### Summary
+
+Task: [SD-???](https://saritasa.atlassian.net/browse/SD-???)
+
+<!--
+Description should contain link to valid task in Jira, short description of the implemented feature.
+Please ensure that actions passed.
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2024-03-29
+
+[v2.6]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-rocks-kubernetes-aws/pull/298)
+- Update `fastlane-android` action - update 3rd party steps to actual versions (get rid of deprecated warnings)
+- Build android apps on self-hosted github runners in Rocks cluster
+- Fix `google-services.json` file creation
+- Fix warning about UTF-8 locale required for fastlane


### PR DESCRIPTION
Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

- Update `fastlane-android` action - update 3rd party steps to actualized versions (get rid of deprecated warnings)
- Build android apps on self-hosted github runners in Rocks cluster instead of macjenkins (proven to work on https://github.com/saritasa-nest/saritasa-vn-office-automator-android/pull/7)
- Fix `google-services.json` file creation
- Fix warning about UTF-8 locale required for fastlane
- Update deprecated list of CODEOWNERS

2.6 tag is created. I will publish 2.6 release once this PR is approved and I merge it.

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ