### PR TITLE
feat: add comment to github actions summary

### DIFF
--- a/.github/actions/secrets-checks/action.yaml
+++ b/.github/actions/secrets-checks/action.yaml
@@ -97,6 +97,7 @@ runs:
         GITHUB_TOKEN: ${{inputs.github-token}}
         GITLEAKS_LICENSE: ${{inputs.gitleaks-license}}
         GITLEAKS_ENABLE_COMMENTS: false
+        GITLEAKS_ENABLE_SUMMARY: false
 
     - name: add gitleaks check results to data file
       shell: bash
@@ -113,12 +114,18 @@ runs:
 
     - name: create pr comment with checks results
       shell: bash
-      if: always() && github.event_name == 'pull_request' && inputs.enable-pr-comment == 'true'
+      if: always()
       run: |
         python3 ${{ github.action_path }}/scripts/generate-message.py \
           ${{ github.action_path }}/templates/pr-comment-template.j2 \
           data.json \
           pr-comment.md
+
+    - name: add comment to github actions summary
+      if: always()
+      shell: bash
+      run: |
+        cat pr-comment.md > $GITHUB_STEP_SUMMARY
 
     - name: find pr comment with check results
       uses: peter-evans/find-comment@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-02-12
+
+[v3.3]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/15)
+- Added summary for action with information about the result of `secrets-checks`
+
 ## 2025-01-30
 
 [v3.2]


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

- When a `trivy` check is run on a commit and fails, developers were previously not informed about the unencrypted secrets and vulnerabilities detected
Now, this information will be displayed in the GitHub Actions summary