### PR TITLE
feat: add port option

### DIFF
--- a/.github/workflows/ci-wordpress-rollback.yaml
+++ b/.github/workflows/ci-wordpress-rollback.yaml
@@ -18,6 +18,11 @@ on:
         required: true
         type: string
         description: 'The address of the server'
+      server_port:
+        required: false
+        type: string
+        default: '22'
+        description: 'The port of the server'
       username:
         type: string
         required: true
@@ -84,7 +89,7 @@ jobs:
       # Adding server ip to known_hosts
       - name: Update known_hosts
         run: |
-          ssh-keyscan -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
 
       # Rollback of the release
       - name: Ansistrano rollback
@@ -96,6 +101,7 @@ jobs:
           ANSIBLE_PIPELINING: True
           # User for connect via ssh (See https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_REMOTE_USER)
           ANSIBLE_REMOTE_USER: ${{ inputs.USERNAME }}
+          ANSIBLE_REMOTE_PORT: ${{ inputs.SERVER_PORT }}
         run: |
           ansible-playbook -i \
           ${{ inputs.HOST }}, \

--- a/.github/workflows/ci-wordpress-rollback.yaml
+++ b/.github/workflows/ci-wordpress-rollback.yaml
@@ -45,8 +45,8 @@ on:
         description: 'Specify the current version of Python to install the current version of ansible'
       ansible_version:
         required: true
-        type: number
-        default: 2.16.6
+        type: string
+        default: '2.16.6'
         description: 'Specify the current version of Ansible to install'
       runner:
         required: false

--- a/.github/workflows/ci-wordpress-rollback.yaml
+++ b/.github/workflows/ci-wordpress-rollback.yaml
@@ -14,7 +14,7 @@ on:
   workflow_call:
     inputs:
       # Build configuration
-      host:
+      server_host:
         required: true
         type: string
         description: 'The address of the server'
@@ -89,7 +89,7 @@ jobs:
       # Adding server ip to known_hosts
       - name: Update known_hosts
         run: |
-          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.SERVER_HOST }} >> ~/.ssh/known_hosts
 
       # Rollback of the release
       - name: Ansistrano rollback
@@ -104,7 +104,7 @@ jobs:
           ANSIBLE_REMOTE_PORT: ${{ inputs.SERVER_PORT }}
         run: |
           ansible-playbook -i \
-          ${{ inputs.HOST }}, \
+          ${{ inputs.SERVER_HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
           'deploy_path=${{ inputs.DEPLOY_PATH }}'

--- a/.github/workflows/ci-wordpress-rollback.yaml
+++ b/.github/workflows/ci-wordpress-rollback.yaml
@@ -107,4 +107,4 @@ jobs:
           ${{ inputs.HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
-          'deploy_path=${{ inputs.DEPLOY_PATH }} \
+          'deploy_path=${{ inputs.DEPLOY_PATH }}'

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -17,8 +17,8 @@ on:
         description: 'The address of the server'
       server_port:
         required: false
-        type: number
-        default: 22
+        type: string
+        default: '22'
         description: 'The port of the server'
       username:
         type: string

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     inputs:
       # Build configuration
-      host:
+      server_host:
         required: true
         type: string
         description: 'The address of the server'
@@ -95,7 +95,7 @@ jobs:
       # Adding server ip to known_hosts
       - name: Update known_hosts
         run: |
-          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.SERVER_HOST }} >> ~/.ssh/known_hosts
 
       # Deploy the project
       - name: Ansistrano deploy
@@ -111,7 +111,7 @@ jobs:
           ANSIBLE_REMOTE_PORT: ${{ inputs.SERVER_PORT }}
         run: |
           ansible-playbook -i \
-          ${{ inputs.HOST }}, \
+          ${{ inputs.SERVER_HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
           "ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -108,13 +108,13 @@ jobs:
           # We increase the performance of the pipeline (See https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-pipelining)
           ANSIBLE_PIPELINING: True
           ANSIBLE_REMOTE_USER: ${{ inputs.USERNAME }}
+          ANSIBLE_REMOTE_PORT: ${{ inputs.SERVER_PORT }}
         run: |
           ansible-playbook -i \
           ${{ inputs.HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
-          "ansible_port=${{ inputs.SERVER_PORT }} \
-           ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
+          "ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
            deploy_path=${{ inputs.DEPLOY_PATH }} \
            deploy_repo=${{ inputs.DEPLOY_REPO }} \
            deploy_branch=${{ inputs.DEPLOY_BRANCH }}"

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -15,6 +15,11 @@ on:
         required: true
         type: string
         description: 'The address of the server'
+      server_port:
+        required: false
+        type: number
+        default: 22
+        description: 'The port of the server'
       username:
         type: string
         required: true
@@ -108,6 +113,7 @@ jobs:
           ${{ inputs.HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
+          ${{ inputs.SERVER_PORT }} \
           "ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
            deploy_path=${{ inputs.DEPLOY_PATH }} \
            deploy_repo=${{ inputs.DEPLOY_REPO }} \

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -95,7 +95,7 @@ jobs:
       # Adding server ip to known_hosts
       - name: Update known_hosts
         run: |
-          ssh-keyscan -p ${{ env.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ inputs.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
 
       # Deploy the project
       - name: Ansistrano deploy

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -113,8 +113,8 @@ jobs:
           ${{ inputs.HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
-          ${{ inputs.SERVER_PORT }} \
-          "ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
+          "ansible_ssh_port=${{ inputs.SERVER_PORT }} \
+           ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
            deploy_path=${{ inputs.DEPLOY_PATH }} \
            deploy_repo=${{ inputs.DEPLOY_REPO }} \
            deploy_branch=${{ inputs.DEPLOY_BRANCH }}"

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -113,7 +113,7 @@ jobs:
           ${{ inputs.HOST }}, \
           ${{ inputs.PLAYBOOK_PATH }} \
           --extra-vars \
-          "ansible_ssh_port=${{ inputs.SERVER_PORT }} \
+          "ansible_port=${{ inputs.SERVER_PORT }} \
            ansistrano_release_version=`date -u +%Y-%m-%d-%H%M%SZ` \
            deploy_path=${{ inputs.DEPLOY_PATH }} \
            deploy_repo=${{ inputs.DEPLOY_REPO }} \

--- a/.github/workflows/ci-wordpress.yaml
+++ b/.github/workflows/ci-wordpress.yaml
@@ -95,7 +95,7 @@ jobs:
       # Adding server ip to known_hosts
       - name: Update known_hosts
         run: |
-          ssh-keyscan -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan -p ${{ env.SERVER_PORT }} -H ${{ inputs.HOST }} >> ~/.ssh/known_hosts
 
       # Deploy the project
       - name: Ansistrano deploy


### PR DESCRIPTION
### Summary

Task: [KMM-26](https://saritasa.atlassian.net/browse/KMM-26)

- Added posibility to set a host port for connect via ssh in `ci-wordpress` and `ci-wordpress-rollback` workflows, if the hosting use no standart port number.

Tested on KMM project:
- [deploy](https://github.com/saritasa-nest/kmm-wordpress/actions/runs/14509885978)
- [rollback](https://github.com/saritasa-nest/kmm-wordpress/actions/runs/14510200487)

[KMM-26]: https://saritasa.atlassian.net/browse/KMM-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ