### PR TITLE
feat: always add pre-commit-tools folder to PATH

### DIFF
--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -102,8 +102,11 @@ runs:
           fi
         done <<< "${{ inputs.tools-list }}"
 
-        # Make directory available to all subsequent actions in this job
-        echo $tools_dir >> $GITHUB_PATH
+    # Add pre-commit-tools directory to PATH for all subsequent actions in this job
+    # So even if the previous step was skipped, tools would stil be added to GITHUB_PATH
+    - name: Add pre-commit-tools to PATH
+      shell: bash
+      run: echo "$HOME/pre-commit-tools" >> $GITHUB_PATH
 
     # Setup Node.js since `terraform_fmt` depends on it
     - name: Setup node


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

- move adding `pre-commit-tools` folder to GITHUB_PATH to a separate step

Previously, ```echo $tools_dir >> $GITHUB_PATH``` was inside of the `Install pre-commit tools from the tools-list input` step, that was skipped if cache was hit. This was resulting in the `command not found` errors for tools like `trivy`, `tflint` and `terraform-docs`.

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->
