### PR TITLE
fix: update pr comment template path SD-373

### DIFF
--- a/.github/actions/build-image/README.md
+++ b/.github/actions/build-image/README.md
@@ -185,7 +185,7 @@ jobs:
     if: |
       github.event.pull_request.user.login == 'saritasa-renovatebot[bot]' &&
       github.event.label.name == 'build-images'
-    uses: saritasa-nest/saritasa-github-actions/.github/workflows/build-images.yaml@v4.3
+    uses: saritasa-nest/saritasa-github-actions/.github/workflows/build-images.yaml@v4.5
     with:
       runner: saritasa-rocks-eks
     secrets:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Build and publish backend buildpack builder image
-        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@v4.4
+        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@v4.5
         with:
           context: ${{ matrix.context }}
           dockerhub_token: ${{ secrets.dockerhub_token }}
@@ -105,6 +105,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Checkout pr comment template
+        uses: actions/checkout@v5
+        with:
+          repository: saritasa-nest/saritasa-github-actions
+          sparse-checkout: .github/actions/build-image/pr-comment-template.j2
+          path: pr-comment-template
+          sparse-checkout-cone-mode: false
       - name: Download data artifacts data for the PR comment template
         uses: actions/download-artifact@v5
         with:
@@ -129,7 +136,7 @@ jobs:
         uses: cuchi/jinja2-action@v1.3.0
         with:
           data_file: pr-comment-data.json
-          template: .github/actions/build-image/pr-comment-template.j2
+          template: pr-comment-template/.github/actions/build-image/pr-comment-template.j2
           output_file: pr-comment.md
       - name: Create or update a PR comment with docker build results
         uses: edumserrano/find-create-or-update-comment@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-09-29
+
+[v4.5]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/29)
+- Fixed extraction of PR comment template for `build-images` workflow
+
 ## 2025-09-02
 
 [v4.4]


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Add extraction of PR comment template for `build-images` workflow.
Previously, the error did not occur because the template was present in the test repository.

<img width="2153" height="316" alt="image" src="https://github.com/user-attachments/assets/e0d7112b-0d90-4dd0-a76c-d311db4cbfc2" />

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->
