### PR TITLE
feat: update build image

### DIFF
--- a/.github/actions/build-image/README.md
+++ b/.github/actions/build-image/README.md
@@ -185,7 +185,7 @@ jobs:
     if: |
       github.event.pull_request.user.login == 'saritasa-renovatebot[bot]' &&
       github.event.label.name == 'build-images'
-    uses: saritasa-nest/saritasa-github-actions/.github/workflows/build-images.yaml@v4.3
+    uses: saritasa-nest/saritasa-github-actions/.github/workflows/build-images.yaml@v4.5
     with:
       runner: saritasa-rocks-eks
     secrets:

--- a/.github/actions/build-image/README.md
+++ b/.github/actions/build-image/README.md
@@ -24,7 +24,7 @@ When invoked for a particular build context and environment, the action performs
 
 4) Log in to AWS ECR.
 
-5) Determine the image tag to use by reading `ARG IMAGE_SHA=...` from `<context>/Dockerfile` and finding the matching tag in Docker Hub for the repo specified by `docker_repository` (optionally authenticated to avoid rate limits).
+5) Determine the image tag to use by reading `ARG IMAGE_SHA=...` from `<context>/<dockerfile>` and finding the matching tag in Docker Hub for the repo specified by `docker_repository` (optionally authenticated to avoid rate limits).
 
 6) Build and push the Docker image to ECR with two tags: the discovered tag and `latest`.
 
@@ -35,6 +35,7 @@ When invoked for a particular build context and environment, the action performs
 #### Inputs
 
 - `context` (required): Relative path to the folder that contains the `Dockerfile` and build context.
+- `dockerfile` (required): Name of the Dockerfile to build.
 - `environment` (required): One of `dev`, `staging`, `prod`.
 - `slack_webhook_url` (required): Slack Incoming Webhook URL to post build status.
 - `dockerhub_username` (optional): Docker Hub username for read-only auth (reduces rate limits when querying tags).
@@ -52,7 +53,7 @@ When invoked for a particular build context and environment, the action performs
 
 #### Dockerfile requirement
 
-Your `<context>/Dockerfile` must contain a line with the base image digest:
+Your `<context>/<dockerfile>` must contain a line with the base image digest:
 
 ```Dockerfile
 ARG IMAGE_SHA=sha256:...
@@ -144,9 +145,9 @@ Example configuration for updating buildpack Docker images:
 # │ To start the workflow, add the `build-images` label to the pull request.                                                                             │
 # │ The workflow extracts environments for which images need to be built from the labels `build:dev`, `build:staging`, `build:prod`.                     │
 # │ Then the workflow checks which images' Dockerfiles were changed and builds and publishes them.                                                       │
-# │ The workflow needs the following environment variables:                                                                                               │
-# │ - `aws_account` - AWS account ID for the current environment                                                                                          │
-# │ - `aws_gha_role` - role for access to AWS using the GitHub OIDC provider                                                                              │
+# │ The workflow needs the following environment variables:                                                                                              │
+# │ - `aws_account` - AWS account ID for the current environment                                                                                         │
+# │ - `aws_gha_role` - role for access to AWS using the GitHub OIDC provider                                                                             │
 # │ - `aws_region` - the region in which the ECR for the custom image is located                                                                         │
 # │ - `client` - project name                                                                                                                            │
 # │ - `docker_repository` - the base image used in the Dockerfile on which the custom image is based                                                     │
@@ -159,7 +160,7 @@ Example configuration for updating buildpack Docker images:
 # │ - <context>.env                                                                                                                                      │
 # │ - <context>.env.<environment>                                                                                                                        │
 # │                                                                                                                                                      │
-# │ A separate job is launched for each image. It builds the image, publishes it to AWS ECR, and sends a notification                                     │
+# │ A separate job is launched for each image. It builds the image, publishes it to AWS ECR, and sends a notification                                    │
 # │ to the Slack channel `project-<client>-docker-images`. After all builds are completed, a comment is created in the pull request.                     │
 # │ If the build is successful, the workflow will add an `auto-merge` label allowing automatic PR merge, and the PR will be merged by Mergeable.         │
 # │                                                                                                                                                      │

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -62,6 +62,10 @@ runs:
     - name: Login to AWS ECR
       id: ecr
       uses: aws-actions/amazon-ecr-login@v2.0.1
+      with:
+        registry-type: ${{ env.ECR_TYPE }}
+      env:
+        ECR_TYPE: ${{ startsWith(env.ecr_repository_uri, 'public.ecr.aws') && 'public' || 'private' }}
     - name: Get DockerHub API token
       id: dockerhub-token
       shell: bash

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -14,6 +14,9 @@ inputs:
   context:
     description: folder with files required to build docker image
     required: true
+  dockerfile:
+    description: dockerfile name
+    required: true
   dockerhub_registry_url:
     description: dockerhub api registry url
     required: false
@@ -59,13 +62,18 @@ runs:
       with:
         aws-region: ${{ env.aws_region }}
         role-to-assume: ${{ env.aws_gha_role }}
+    - name: Detect ECR type
+      shell: bash
+      run: |
+        echo "ECR_TYPE=private" >> $GITHUB_ENV
+        if [[ "${{ env.ecr_repository_uri }}" == public.ecr.aws* ]]; then
+          echo "ECR_TYPE=public" >> $GITHUB_ENV
+        fi
     - name: Login to AWS ECR
       id: ecr
       uses: aws-actions/amazon-ecr-login@v2.0.1
       with:
         registry-type: ${{ env.ECR_TYPE }}
-      env:
-        ECR_TYPE: ${{ startsWith(env.ecr_repository_uri, 'public.ecr.aws') && 'public' || 'private' }}
     - name: Get DockerHub API token
       id: dockerhub-token
       shell: bash
@@ -85,7 +93,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        target_digest=$(grep '^ARG IMAGE_SHA=' ${{ inputs.context }}/Dockerfile | cut -d= -f2)
+        target_digest=$(grep '^ARG IMAGE_SHA=' ${{ inputs.context }}/${{ inputs.dockerfile }} | cut -d= -f2)
         echo "Image digest: ${target_digest}"
 
         # find a tag whose digest matches the given one and which is not called 'latest'
@@ -109,14 +117,30 @@ runs:
         fi
         echo "✅ Matching tag found: ${tag}"
         echo "image_tag=$tag" >> $GITHUB_OUTPUT
+    - name: Determine Dockerfile suffix
+      id: dockerfile-suffix
+      shell: bash
+      run: |
+        filename="${{ inputs.dockerfile }}"
+        # runner-jammy.Dockerfile → jammy
+        base=$(basename "$filename" .Dockerfile)
+        if [[ "$base" == *"-"* ]]; then
+          suffix="-${base#*-}"
+        else
+          suffix=""
+        fi
+        echo "suffix=$suffix" >> $GITHUB_OUTPUT
     - name: Build and push docker image
       id: build-image
       uses: docker/build-push-action@v6.18.0
       with:
         context: ${{ inputs.context }}
+        file: ${{ inputs.context }}/${{ inputs.dockerfile }}
         platforms: ${{ env.platforms }}
         push: true
-        tags: ${{ env.ecr_repository_uri }}:${{ steps.tag.outputs.image_tag }}, ${{ env.ecr_repository_uri }}:latest
+        tags: |
+          ${{ env.ecr_repository_uri }}:${{ steps.tag.outputs.image_tag }}${{ steps.dockerfile-suffix.outputs.suffix }},
+          ${{ env.ecr_repository_uri }}:latest${{ steps.dockerfile-suffix.outputs.suffix }}
     - name: Configure settings for PR comment
       id: pr-data
       if: ${{ !cancelled() }}
@@ -168,6 +192,7 @@ runs:
           echo "message=😞 The build of *${{ inputs.context }}* image failed." >> $GITHUB_OUTPUT
         else
           echo "color=28a745" >> $GITHUB_OUTPUT
+          echo "message=The build of *${{ inputs.context }}* image with version *${{ steps.tag.outputs.image_tag }}* was successful! :rocket:" >> $GITHUB_OUTPUT
         fi
     - name: Send notification to slack
       if: ${{ !cancelled() }}
@@ -195,4 +220,4 @@ runs:
                   value: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.job }}>
                 - title: Repository
                   short: true
-                  value: <https://github.com/${{ github.repository }}/blob/main/${{ inputs.context }}/Dockerfile|${{ github.repository }}>
+                  value: <https://github.com/${{ github.repository }}/blob/main/${{ inputs.context }}/${{ inputs.dockerfile }}|${{ github.repository }}>

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -189,7 +189,7 @@ runs:
         set -euo pipefail
         if ${{ contains(steps.*.outcome, 'failure') }}; then
           echo "color=cc0000" >> $GITHUB_OUTPUT
-          echo "message=😞 The build of *${{ inputs.context }}* image failed." >> $GITHUB_OUTPUT
+          echo "message=😞 The build of *${{ inputs.context }}* image with version *${{ steps.tag.outputs.image_tag }}* failed." >> $GITHUB_OUTPUT
         else
           echo "color=28a745" >> $GITHUB_OUTPUT
           echo "message=The build of *${{ inputs.context }}* image with version *${{ steps.tag.outputs.image_tag }}* was successful! :rocket:" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           files: |
             **/Dockerfile
+            **/*.Dockerfile
       - name: Extract environments from labels and prepare matrix values
         id: data
         run: |
@@ -66,12 +67,14 @@ jobs:
           for env in ${environments[@]}; do
             for file in ${modified_files[@]}; do
               context=$(dirname "${file}")
+              dockerfile=$(basename "${file}")
               # add a new element to the matrix with the received relative path to the Dockerfile
               # for each environment
               matrix=$(echo "${matrix}" | jq \
                 --arg context "${context}" \
                 --arg env "${env}" \
-                '.include += [{"environment": $env, "context": $context}]')
+                --arg dockerfile "${dockerfile}" \
+                '.include += [{"environment": $env, "context": $context, "dockerfile": $dockerfile}]')
             done
           done
           echo "matrix=$(echo ${matrix} | jq -c .)"
@@ -88,9 +91,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Build and publish backend buildpack builder image
-        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@v4.5
+        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@feature/update-build-image
         with:
           context: ${{ matrix.context }}
+          dockerfile: ${{ matrix.dockerfile }}
           dockerhub_token: ${{ secrets.dockerhub_token }}
           dockerhub_username: ${{ secrets.dockerhub_username }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -56,10 +56,10 @@ jobs:
           # which looks like this:
           # {
           #   "include": [
-          #     {"environment": "dev", "context": "buildpacks/backend/builder"},
-          #     {"environment": "dev", "context": "buildpacks/backend/runner"},
-          #     {"environment": "prod", "context": "buildpacks/backend/builder"},
-          #     {"environment": "prod", "context": "buildpacks/backend/runner"}
+          #     {"environment": "dev", "context": "buildpacks/backend/builder", "dockerfile": "Dockerfile"},
+          #     {"environment": "dev", "context": "buildpacks/backend/runner", "dockerfile": "Dockerfile"},
+          #     {"environment": "prod", "context": "buildpacks/backend/builder", "dockerfile": "Dockerfile"},
+          #     {"environment": "prod", "context": "buildpacks/backend/runner", "dockerfile": "Dockerfile"}
           #   ]
           # }
           matrix='{"include":[]}'

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
       - name: Build and publish backend buildpack builder image
-        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@v4.4
+        uses: saritasa-nest/saritasa-github-actions/.github/actions/build-image@v4.5
         with:
           context: ${{ matrix.context }}
           dockerhub_token: ${{ secrets.dockerhub_token }}
@@ -105,6 +105,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Checkout pr comment template
+        uses: actions/checkout@v5
+        with:
+          repository: saritasa-nest/saritasa-github-actions
+          sparse-checkout: .github/actions/build-image/pr-comment-template.j2
+          path: pr-comment-template
+          sparse-checkout-cone-mode: false
       - name: Download data artifacts data for the PR comment template
         uses: actions/download-artifact@v5
         with:
@@ -129,7 +136,7 @@ jobs:
         uses: cuchi/jinja2-action@v1.3.0
         with:
           data_file: pr-comment-data.json
-          template: .github/actions/build-image/pr-comment-template.j2
+          template: pr-comment-template/.github/actions/build-image/pr-comment-template.j2
           output_file: pr-comment.md
       - name: Create or update a PR comment with docker build results
         uses: edumserrano/find-create-or-update-comment@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-10-06
+
+[v4.6]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/31)
+- Adaptation of the `build-image` action for use in `saritasa-devops-docker-images`
+
 ## 2025-09-29
 
 [v4.5]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-09-29
+
+[v4.5]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/29)
+- Fixed extraction of PR comment template for `build-images` workflow
+
 ## 2025-09-02
 
 [v4.4]


### PR DESCRIPTION
### Summary

Task: [SD-1356](https://saritasa.atlassian.net/browse/SD-1356)

Adaptation of the action for use in [saritasa-devops-docker-images](https://github.com/saritasa-nest/saritasa-devops-docker-images). This way, we no longer need to publish new images manually — we can simply update all tags to latest.

- Added `ECR_TYPE` — by default, login was attempted to a private ECR, but for rocks we use a public ECR instead
- Fixed the message for successful image publication
<img width="808" height="228" alt="image" src="https://github.com/user-attachments/assets/c871ef75-0885-4f95-8609-b2886e9e0237" />

- Added the `Detect Dockerfile Suffix` step—extracts the suffix (e.g.,` -jammy ` from `runner-jammy.Dockerfile`) for inclusion in the image tag. This is necessary because all images are published to a single ECR, and using only numeric tags (e.g., `0.1.96`) doesn't allow distinguishing between image variations 
<img width="1305" height="129" alt="image" src="https://github.com/user-attachments/assets/9277b3cc-4eb5-4349-a245-6ef56b7e088f" />

-  the new image has two tags: `latest-jammy` and `0.1.96-jammy`
<img width="1229" height="132" alt="image" src="https://github.com/user-attachments/assets/c466b561-4d1e-42e0-bcf7-307e3c396225" />



[SD-1356]: https://saritasa.atlassian.net/browse/SD-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ