### PR TITLE
Refactor security audit

### DIFF
--- a/.github/actions/security-audit/action.yaml
+++ b/.github/actions/security-audit/action.yaml
@@ -1,10 +1,6 @@
 name: security-audit
 description: Find unencrypted secrets and vulnerabilities in the code with Gitleaks and Trivy
 inputs:
-  cache-version:
-    description: Bump this value to reset the apt package cache
-    required: false
-    default: "1.1"
   enable-gitleaks-check:
     description: |
       Enable gitleaks check
@@ -36,14 +32,14 @@ inputs:
   gitleaks-slack-webhook:
     description: Slack webhook secret for `team-devops-expose-secrets` channel
     required: true
-  python-version:
-    description: Python version to install
-    required: false
-    default: "3.13"
   trivy-version:
     description: Trivy version to install
     required: false
     default: "v0.69.2"
+  apt-cache-version:
+    description: Bump this value to reset the apt package cache
+    required: false
+    default: "1.2"
 
 runs:
   using: composite
@@ -54,29 +50,22 @@ runs:
       run: |
         exit 0
 
-    - name: Cache apt packages
-      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+    - name: Install uv
+      id: setup-uv
+      uses: astral-sh/setup-uv@v7
       with:
-        packages: moreutils python3-pip
-        version: ${{inputs.cache-version}}
+        enable-cache: true
+        activate-environment: true
+        cache-python: true
+        cache-suffix: "security-audit"
+        working-directory: ${{github.action_path}}
 
-    - name: Cache pip
-      uses: actions/cache@v4
+
+    - name: Install sponge(from moreutils package) for editing data.json in-place
+      uses: awalsh128/cache-apt-pkgs-action@v1
       with:
-        path: ~/.cache/pip
-        key: pip-${{runner.os}}-jinja2
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{inputs.python-version}}
-
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo apt update
-        sudo apt-get install -y moreutils python3-pip
-        pip3 install jinja2
+        packages: moreutils
+        version: ${{ inputs.apt-cache-version }}
 
     - name: Install trivy
       uses: aquasecurity/setup-trivy@v0.2.6
@@ -84,6 +73,7 @@ runs:
         version: ${{inputs.trivy-version}}
 
     - name: Prepare data.json for PR and Slack comments
+      working-directory: ${{github.action_path}}
       shell: bash
       run: |
         jq -n \
@@ -106,7 +96,7 @@ runs:
         scan-ref: .
         format: sarif
         exit-code: 1
-        output: trivy-results.sarif
+        output: ${{github.action_path}}/trivy-results.sarif
         scanners: secret
         skip-setup-trivy: true
         severity: HIGH,CRITICAL
@@ -115,10 +105,11 @@ runs:
 
     - name: Add trivy failure check results to data file
       shell: bash
+      working-directory: ${{github.action_path}}
       if: always() && steps.trivy-check.conclusion == 'failure'
       run: |
-        python3 ${{github.action_path}}/scripts/sarif-to-json.py trivy-results.sarif trivy-output.json trivy
-        # Add the contents of the trivy-output.json file to data.json, from which 
+        uv run scripts/sarif-to-json.py trivy-results.sarif trivy-output.json trivy
+        # Add the contents of the trivy-output.json file to data.json, from which
         # notifications about the results of secret checks are generated
         jq -s '.[0] * .[1]' trivy-output.json data.json | sponge data.json
         echo reactions="confused" > $GITHUB_ENV
@@ -132,7 +123,7 @@ runs:
         scan-ref: .
         format: sarif
         exit-code: 1
-        output: vulnerability-results.sarif
+        output: ${{github.action_path}}/vulnerability-results.sarif
         scanners: vuln
         skip-setup-trivy: true
         severity: HIGH,CRITICAL
@@ -141,10 +132,11 @@ runs:
 
     - name: Add vulnerability failure check results to data file
       shell: bash
+      working-directory: ${{github.action_path}}
       if: always() && steps.vulnerability-check.conclusion == 'failure'
       run: |
-        python3 ${{github.action_path}}/scripts/sarif-to-json.py vulnerability-results.sarif vulnerability-output.json trivy
-        # Add the contents of the vulnerability-output.json file to data.json, from which 
+        uv run scripts/sarif-to-json.py vulnerability-results.sarif vulnerability-output.json trivy
+        # Add the contents of the vulnerability-output.json file to data.json, from which
         # notifications about the results of secret checks are generated
         if [[ -f vulnerability-output.json ]]; then
           jq -s '.[0] * .[1]' vulnerability-output.json data.json | sponge data.json
@@ -163,10 +155,11 @@ runs:
 
     - name: Add gitleaks check results to data file
       shell: bash
+      working-directory: ${{github.action_path}}
       if: always() && inputs.enable-gitleaks-check == 'true'
       run: |
-        python3 ${{github.action_path}}/scripts/sarif-to-json.py results.sarif gitleaks-output.json gitleaks
-        # Add the contents of the gitleaks-output.json file to data.json, from which 
+        uv run scripts/sarif-to-json.py ${{github.workspace}}/results.sarif gitleaks-output.json gitleaks
+        # Add the contents of the gitleaks-output.json file to data.json, from which
         # notifications about the results of secret checks are generated
         if [[ -f gitleaks-output.json ]]; then
           jq -s '.[0] * .[1]' gitleaks-output.json data.json | sponge data.json
@@ -175,22 +168,23 @@ runs:
 
     - name: Prepare PR comment file
       shell: bash
+      working-directory: ${{github.action_path}}
       if: always()
       run: |
         TEMPLATES=()
         if [[ "${{inputs.enable-vulnerability-checks}}" == "true" ]]; then
-          TEMPLATES+=("${{github.action_path}}/templates/pr-comment-vulnerabilities-template.j2")
+          TEMPLATES+=("templates/pr-comment-vulnerabilities-template.j2")
         fi
         if [[ "${{inputs.enable-gitleaks-check}}" == "true" ]] || [[ "${{inputs.enable-trivy-check}}" == "true" ]]; then
-          TEMPLATES+=("${{github.action_path}}/templates/pr-comment-secrets-template.j2")
+          TEMPLATES+=("templates/pr-comment-secrets-template.j2")
         fi
         for TEMPLATE in "${TEMPLATES[@]}"; do
           OUT=pr-comment-secrets.md
           if [[ "$TEMPLATE" == *vulnerabilities* ]]; then
             OUT=pr-comment-vulnerabilities.md
           fi
-          python3 ${{github.action_path}}/scripts/generate-message.py "$TEMPLATE" data.json "$OUT"
-          cat "$OUT" >> $GITHUB_STEP_SUMMARY
+          uv run scripts/generate-message.py "$TEMPLATE" data.json "${{github.workspace}}/$OUT"
+          cat "${{github.workspace}}/$OUT" >> $GITHUB_STEP_SUMMARY
         done
 
     - name: Find PR comment with secret-check results
@@ -240,12 +234,13 @@ runs:
     # which could make it difficult to track critical secret leaks.
     - name: Prepare and send message to Slack
       shell: bash
+      working-directory: ${{github.action_path}}
       if: always() && (inputs.enable-gitleaks-check == 'true' || inputs.enable-trivy-check == 'true')
       run: |
-        python3 ${{github.action_path}}/scripts/generate-message.py \
-          ${{github.action_path}}/templates/slack-message-template.j2 \
-          data.json \
-          slack-message.json
+        uv run scripts/generate-message.py \
+               templates/slack-message-template.j2 \
+               data.json \
+               slack-message.json
         if [[ -s "slack-message.json" ]]; then
           curl -X POST -H 'Content-type: application/json' --data @slack-message.json ${{inputs.gitleaks-slack-webhook}}
         fi

--- a/.github/actions/security-audit/pyproject.toml
+++ b/.github/actions/security-audit/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "scripts"
+version = "0.0.0"
+description = "Scripts for security audit"
+readme = "README.md"
+requires-python = "==3.14.*"
+dependencies = [
+    "jinja2==3.1.6",
+]

--- a/.github/actions/security-audit/scripts/generate-message.py
+++ b/.github/actions/security-audit/scripts/generate-message.py
@@ -1,6 +1,6 @@
 import argparse
 import json
-from jinja2 import Template
+import jinja2
 
 parser = argparse.ArgumentParser()
 parser.add_argument('template_file', type=str, help='Path to the jinja2 template file')
@@ -12,6 +12,6 @@ args = parser.parse_args()
 with open(args.data_file) as file:
     data = json.load(file)
 with open(args.template_file) as file:
-    template = Template(file.read())
+    template = jinja2.Template(file.read())
 with open(args.output_file, "w") as file:
     file.write(template.render(data))

--- a/.github/actions/security-audit/scripts/sarif-to-json.py
+++ b/.github/actions/security-audit/scripts/sarif-to-json.py
@@ -2,10 +2,11 @@ import argparse
 import json
 import os
 import re
-from collections import defaultdict
-from typing import NamedTuple
+import collections
+import dataclasses
 
-class BaseInfo(NamedTuple):
+@dataclasses.dataclass
+class BaseInfo:
     """
     Base information of the scan result items.
     """
@@ -44,27 +45,27 @@ def convert_gitleaks_results_to_json(run: dict[str, any]) -> dict[str, any]:
     """
     Converts gitleaks analysis results into json format
 
-    Args: 
+    Args:
         run (dict): Data of the 'run' field from SARIF file
-    Returns: 
+    Returns:
         dict: A JSON object containing the conversion results
     """
-    files = defaultdict(dict)
+    files = collections.defaultdict(dict)
 
     for item in run['results']:
-        location, file_name, start_line, end_line = extract_base_info(item)
-        file_key = f"{start_line}-{end_line}"
+        base_info = extract_base_info(item)
+        file_key = f"{base_info.start_line}-{base_info.end_line}"
 
-        files[file_name].setdefault(file_key, {
-            'name': file_name,
+        files[base_info.file_name].setdefault(file_key, {
+            'name': base_info.file_name,
             'commits': [],
-            'startLine': start_line,
-            'endLine': end_line,
+            'startLine': base_info.start_line,
+            'endLine': base_info.end_line,
             'ruleId': item['ruleId'],
         })
 
         commitSha = item['partialFingerprints']['commitSha']
-        files[file_name][file_key]['commits'].append(commitSha)
+        files[base_info.file_name][file_key]['commits'].append(commitSha)
 
     return {
         'gitleaks': {
@@ -84,21 +85,21 @@ def strip_tags(text):
 
 def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
     """
-    This function processes SARIF scan results and returns a dictionary 
+    This function processes SARIF scan results and returns a dictionary
     containing unencrypted secrets and vulnerabilities found in the scanned files.
 
-    Args: 
+    Args:
         run (dict): Data of the 'run' field from SARIF file
-    Returns: 
+    Returns:
         dict: A JSON object containing the conversion results
             {
                 'vulnerabilities': {...},  # Vulnerabilities results
                 'trivy': {...},            # Secrets results
             }
     """
-    secrets = defaultdict(list)
-    vulnerability_rules = defaultdict(list)
-    vulnerabilities = defaultdict(list)
+    secrets = collections.defaultdict(list)
+    vulnerability_rules = collections.defaultdict(list)
+    vulnerabilities = collections.defaultdict(list)
 
     # Preprocess rules to extract vulnerability descriptions.
     # This allows us to later supplement scan results by matching rule ID → description.
@@ -112,12 +113,12 @@ def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
 
     # Extract the following data from scan results:
     #   file name, start and end line numbers (to generate precise links to the content), and severity level.
-    # For vulnerabilities, we additionally extract 
+    # For vulnerabilities, we additionally extract
     #   package name, installed and fixed versions, rule description.
     for item in run['results']:
-        location, file_name, start_line, end_line = extract_base_info(item)
+        base_info = extract_base_info(item)
         # To specify the error type, need to convert the `severity` variable.
-        # From: 
+        # From:
         #   Artifact: app/config.yaml
         #   Type: Secret GitHub Fine-grained personal access tokens
         #   Severity: CRITICAL
@@ -125,20 +126,20 @@ def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
         #   title: title
         #   token: ********************************************sdf
         #   token-2: *****
-        # To: 
+        # To:
         #   CRITICAL
         severity = item['message']['text'].split('Severity: ')[1].split('\n')[0].strip()
         default = {
-            'name': file_name,
-            'startLine': start_line,
-            'endLine': end_line,
+            'name': base_info.file_name,
+            'startLine': base_info.start_line,
+            'endLine': base_info.end_line,
             'ruleId': item['ruleId'],
             'severity': severity,
         }
         rule = vulnerability_rules.get(item['ruleId'])
         if rule:
             text = item['message']['text']
-            vulnerabilities[file_name].append({
+            vulnerabilities[base_info.file_name].append({
                 'package': text.split('Package: ')[1].split('\n')[0].strip(),
                 'installedVersion': text.split('Installed Version: ')[1].split('\n')[0].strip(),
                 'fixedVersion':  text.split('Fixed Version: ')[1].split('\n')[0].strip(),
@@ -146,7 +147,7 @@ def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
                 **default,
             })
         else:
-            secrets[file_name].append(default.copy())
+            secrets[base_info.file_name].append(default.copy())
     return {
         'vulnerabilities': {
             'totalFiles': len(vulnerabilities.keys()),

--- a/.github/actions/security-audit/uv.lock
+++ b/.github/actions/security-audit/uv.lock
@@ -1,0 +1,56 @@
+version = 1
+revision = 3
+requires-python = "==3.14.*"
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "scripts"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "jinja2" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "jinja2", specifier = "==3.1.6" }]


### PR DESCRIPTION
### Summary

Task: [SA3P-22](https://saritasa.atlassian.net/browse/SA3P-22)

Test PR: https://github.com/saritasa-nest/camp-js-backend/pull/360

- Make Python scripts use uv for stable Python and Jinja2 version
- Update Python setup to use simple UV action instead of apt packages
- Improve usage of  `awalsh128/cache-apt-pkgs-action`

[SA3P-22]: https://saritasa.atlassian.net/browse/SA3P-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ