### PR TITLE
Improve strip_tags

### DIFF
--- a/.github/actions/security-audit/scripts/sarif-to-json.py
+++ b/.github/actions/security-audit/scripts/sarif-to-json.py
@@ -44,9 +44,9 @@ def convert_gitleaks_results_to_json(run: dict[str, any]) -> dict[str, any]:
     """
     Converts gitleaks analysis results into json format
 
-    Args: 
+    Args:
         run (dict): Data of the 'run' field from SARIF file
-    Returns: 
+    Returns:
         dict: A JSON object containing the conversion results
     """
     files = defaultdict(dict)
@@ -74,22 +74,22 @@ def convert_gitleaks_results_to_json(run: dict[str, any]) -> dict[str, any]:
         },
     }
 
-def strip_tags(text):
+def strip_tags(text: str) -> str:
     """
     Removes <p> and </p> tags (with any attributes) and all newline characters from the string.
     This is necessary to avoid breaking markdown table formatting in the final output.
     """
     text = re.sub(r'<\s*/?\s*p[^>]*>', '', text)
-    return text.replace('\n', ' ')
+    return text.replace('\n', ' ').replace('\r', '')
 
 def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
     """
-    This function processes SARIF scan results and returns a dictionary 
+    This function processes SARIF scan results and returns a dictionary
     containing unencrypted secrets and vulnerabilities found in the scanned files.
 
-    Args: 
+    Args:
         run (dict): Data of the 'run' field from SARIF file
-    Returns: 
+    Returns:
         dict: A JSON object containing the conversion results
             {
                 'vulnerabilities': {...},  # Vulnerabilities results
@@ -112,12 +112,12 @@ def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
 
     # Extract the following data from scan results:
     #   file name, start and end line numbers (to generate precise links to the content), and severity level.
-    # For vulnerabilities, we additionally extract 
+    # For vulnerabilities, we additionally extract
     #   package name, installed and fixed versions, rule description.
     for item in run['results']:
         location, file_name, start_line, end_line = extract_base_info(item)
         # To specify the error type, need to convert the `severity` variable.
-        # From: 
+        # From:
         #   Artifact: app/config.yaml
         #   Type: Secret GitHub Fine-grained personal access tokens
         #   Severity: CRITICAL
@@ -125,7 +125,7 @@ def convert_trivy_results_to_json(run: dict[str, any]) -> dict[str, any]:
         #   title: title
         #   token: ********************************************sdf
         #   token-2: *****
-        # To: 
+        # To:
         #   CRITICAL
         severity = item['message']['text'].split('Severity: ')[1].split('\n')[0].strip()
         default = {


### PR DESCRIPTION
### Summary

Now it also removes carriage return characters,
which can also break markdown table formatting in
the final output.

Task: [SA3P-22](https://saritasa.atlassian.net/browse/SA3P-22)

Example of sarif file

```json
{
  "version": "2.1.0",
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
  "runs": [
    {
      "tool": {
        "driver": {
          "fullName": "Trivy Vulnerability Scanner",
          "informationUri": "https://github.com/aquasecurity/trivy",
          "name": "Trivy",
          "rules": [
            {
              "id": "CVE-2026-39892",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "cryptography: Cryptography: Buffer overflow via non-contiguous buffer in API"
              },
              "fullDescription": {
                "text": "cryptography is a package designed to expose cryptographic primitives and recipes to Python developers. From 45.0.0 to before 46.0.7, if a non-contiguous buffer was passed to APIs which accepted Python buffers (e.g. Hash.update()), this could lead to buffer overflows. This vulnerability is fixed in 46.0.7."
              },
              "defaultConfiguration": {
                "level": "warning"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-39892",
              "help": {
                "text": "Vulnerability CVE-2026-39892\nSeverity: MEDIUM\nPackage: cryptography\nFixed Version: 46.0.7\nLink: [CVE-2026-39892](https://avd.aquasec.com/nvd/cve-2026-39892)\ncryptography is a package designed to expose cryptographic primitives and recipes to Python developers. From 45.0.0 to before 46.0.7, if a non-contiguous buffer was passed to APIs which accepted Python buffers (e.g. Hash.update()), this could lead to buffer overflows. This vulnerability is fixed in 46.0.7.",
                "markdown": "**Vulnerability CVE-2026-39892**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|cryptography|46.0.7|[CVE-2026-39892](https://avd.aquasec.com/nvd/cve-2026-39892)|\n\ncryptography is a package designed to expose cryptographic primitives and recipes to Python developers. From 45.0.0 to before 46.0.7, if a non-contiguous buffer was passed to APIs which accepted Python buffers (e.g. Hash.update()), this could lead to buffer overflows. This vulnerability is fixed in 46.0.7."
              },
              "properties": {
                "cvssv40_baseScore": 6.9,
                "cvssv40_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
                "precision": "very-high",
                "security-severity": "5.5",
                "tags": [
                  "vulnerability",
                  "security",
                  "MEDIUM"
                ]
              }
            },
            {
              "id": "CVE-2026-33034",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "Django: Django: Denial of Service via missing or understated Content-Length header in ASGI requests"
              },
              "fullDescription": {
                "text": "An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nASGI requests with a missing or understated `Content-Length` header could\r\nbypass the `DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading\r\n`HttpRequest.body`, allowing remote attackers to load an unbounded request body into\r\nmemory.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Superior for reporting this issue."
              },
              "defaultConfiguration": {
                "level": "error"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-33034",
              "help": {
                "text": "Vulnerability CVE-2026-33034\nSeverity: HIGH\nPackage: django\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-33034](https://avd.aquasec.com/nvd/cve-2026-33034)\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nASGI requests with a missing or understated `Content-Length` header could\r\nbypass the `DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading\r\n`HttpRequest.body`, allowing remote attackers to load an unbounded request body into\r\nmemory.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Superior for reporting this issue.",
                "markdown": "**Vulnerability CVE-2026-33034**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|django|6.0.4, 5.2.13, 4.2.30|[CVE-2026-33034](https://avd.aquasec.com/nvd/cve-2026-33034)|\n\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nASGI requests with a missing or understated `Content-Length` header could\r\nbypass the `DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading\r\n`HttpRequest.body`, allowing remote attackers to load an unbounded request body into\r\nmemory.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Superior for reporting this issue."
              },
              "properties": {
                "cvssv3_baseScore": 7.5,
                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
                "precision": "very-high",
                "security-severity": "7.5",
                "tags": [
                  "vulnerability",
                  "security",
                  "HIGH"
                ]
              }
            },
            {
              "id": "CVE-2026-3902",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "Django: Django: Header spoofing via ambiguous header mapping"
              },
              "fullDescription": {
                "text": "An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`ASGIRequest` allows a remote attacker to spoof headers by exploiting an ambiguous mapping of two header variants (with hyphens or with underscores) to a single version with underscores.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Tarek Nakkouch for reporting this issue."
              },
              "defaultConfiguration": {
                "level": "error"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-3902",
              "help": {
                "text": "Vulnerability CVE-2026-3902\nSeverity: HIGH\nPackage: django\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-3902](https://avd.aquasec.com/nvd/cve-2026-3902)\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`ASGIRequest` allows a remote attacker to spoof headers by exploiting an ambiguous mapping of two header variants (with hyphens or with underscores) to a single version with underscores.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Tarek Nakkouch for reporting this issue.",
                "markdown": "**Vulnerability CVE-2026-3902**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|HIGH|django|6.0.4, 5.2.13, 4.2.30|[CVE-2026-3902](https://avd.aquasec.com/nvd/cve-2026-3902)|\n\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`ASGIRequest` allows a remote attacker to spoof headers by exploiting an ambiguous mapping of two header variants (with hyphens or with underscores) to a single version with underscores.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Tarek Nakkouch for reporting this issue."
              },
              "properties": {
                "cvssv3_baseScore": 7.5,
                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
                "precision": "very-high",
                "security-severity": "7.5",
                "tags": [
                  "vulnerability",
                  "security",
                  "HIGH"
                ]
              }
            },
            {
              "id": "CVE-2026-33033",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "Django: Django: Performance degradation via excessive whitespace in multipart uploads"
              },
              "fullDescription": {
                "text": "An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`MultiPartParser` allows remote attackers to degrade performance by submitting multipart uploads with `Content-Transfer-Encoding: base64` including excessive whitespace.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Seokchan Yoon for reporting this issue."
              },
              "defaultConfiguration": {
                "level": "warning"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-33033",
              "help": {
                "text": "Vulnerability CVE-2026-33033\nSeverity: MEDIUM\nPackage: django\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-33033](https://avd.aquasec.com/nvd/cve-2026-33033)\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`MultiPartParser` allows remote attackers to degrade performance by submitting multipart uploads with `Content-Transfer-Encoding: base64` including excessive whitespace.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Seokchan Yoon for reporting this issue.",
                "markdown": "**Vulnerability CVE-2026-33033**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|MEDIUM|django|6.0.4, 5.2.13, 4.2.30|[CVE-2026-33033](https://avd.aquasec.com/nvd/cve-2026-33033)|\n\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\n`MultiPartParser` allows remote attackers to degrade performance by submitting multipart uploads with `Content-Transfer-Encoding: base64` including excessive whitespace.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Seokchan Yoon for reporting this issue."
              },
              "properties": {
                "cvssv3_baseScore": 6.5,
                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
                "precision": "very-high",
                "security-severity": "6.5",
                "tags": [
                  "vulnerability",
                  "security",
                  "MEDIUM"
                ]
              }
            },
            {
              "id": "CVE-2026-4277",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "Django: Django: Privilege Abuse via Forged POST Data in GenericInlineModelAdmin"
              },
              "fullDescription": {
                "text": "An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdd permissions on inline model instances were not validated on submission of\r\nforged `POST` data in `GenericInlineModelAdmin`.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank N05ec@LZU-DSLab for reporting this issue."
              },
              "defaultConfiguration": {
                "level": "note"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-4277",
              "help": {
                "text": "Vulnerability CVE-2026-4277\nSeverity: LOW\nPackage: django\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-4277](https://avd.aquasec.com/nvd/cve-2026-4277)\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdd permissions on inline model instances were not validated on submission of\r\nforged `POST` data in `GenericInlineModelAdmin`.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank N05ec@LZU-DSLab for reporting this issue.",
                "markdown": "**Vulnerability CVE-2026-4277**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|LOW|django|6.0.4, 5.2.13, 4.2.30|[CVE-2026-4277](https://avd.aquasec.com/nvd/cve-2026-4277)|\n\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdd permissions on inline model instances were not validated on submission of\r\nforged `POST` data in `GenericInlineModelAdmin`.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank N05ec@LZU-DSLab for reporting this issue."
              },
              "properties": {
                "cvssv40_baseScore": 2.3,
                "cvssv40_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
                "precision": "very-high",
                "security-severity": "2.0",
                "tags": [
                  "vulnerability",
                  "security",
                  "LOW"
                ]
              }
            },
            {
              "id": "CVE-2026-4292",
              "name": "LanguageSpecificPackageVulnerability",
              "shortDescription": {
                "text": "Django: Django: Unauthorized instance creation via forged POST data in Admin changelist forms"
              },
              "fullDescription": {
                "text": "An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdmin changelist forms using `ModelAdmin.list_editable` incorrectly allowed new\r\ninstances to be created via forged `POST` data.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Cantina for reporting this issue."
              },
              "defaultConfiguration": {
                "level": "note"
              },
              "helpUri": "https://avd.aquasec.com/nvd/cve-2026-4292",
              "help": {
                "text": "Vulnerability CVE-2026-4292\nSeverity: LOW\nPackage: django\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-4292](https://avd.aquasec.com/nvd/cve-2026-4292)\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdmin changelist forms using `ModelAdmin.list_editable` incorrectly allowed new\r\ninstances to be created via forged `POST` data.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Cantina for reporting this issue.",
                "markdown": "**Vulnerability CVE-2026-4292**\n| Severity | Package | Fixed Version | Link |\n| --- | --- | --- | --- |\n|LOW|django|6.0.4, 5.2.13, 4.2.30|[CVE-2026-4292](https://avd.aquasec.com/nvd/cve-2026-4292)|\n\nAn issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30.\nAdmin changelist forms using `ModelAdmin.list_editable` incorrectly allowed new\r\ninstances to be created via forged `POST` data.\nEarlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected.\nDjango would like to thank Cantina for reporting this issue."
              },
              "properties": {
                "cvssv3_baseScore": 2.7,
                "cvssv3_vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:N",
                "precision": "very-high",
                "security-severity": "2.7",
                "tags": [
                  "vulnerability",
                  "security",
                  "LOW"
                ]
              }
            }
          ],
          "version": "0.69.3"
        }
      },
      "results": [
        {
          "ruleId": "CVE-2026-39892",
          "ruleIndex": 0,
          "level": "warning",
          "message": {
            "text": "Package: cryptography\nInstalled Version: 46.0.6\nVulnerability CVE-2026-39892\nSeverity: MEDIUM\nFixed Version: 46.0.7\nLink: [CVE-2026-39892](https://avd.aquasec.com/nvd/cve-2026-39892)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: cryptography@46.0.6"
              }
            }
          ]
        },
        {
          "ruleId": "CVE-2026-33034",
          "ruleIndex": 1,
          "level": "error",
          "message": {
            "text": "Package: django\nInstalled Version: 5.2.12\nVulnerability CVE-2026-33034\nSeverity: HIGH\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-33034](https://avd.aquasec.com/nvd/cve-2026-33034)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: django@5.2.12"
              }
            }
          ]
        },
        {
          "ruleId": "CVE-2026-3902",
          "ruleIndex": 2,
          "level": "error",
          "message": {
            "text": "Package: django\nInstalled Version: 5.2.12\nVulnerability CVE-2026-3902\nSeverity: HIGH\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-3902](https://avd.aquasec.com/nvd/cve-2026-3902)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: django@5.2.12"
              }
            }
          ]
        },
        {
          "ruleId": "CVE-2026-33033",
          "ruleIndex": 3,
          "level": "warning",
          "message": {
            "text": "Package: django\nInstalled Version: 5.2.12\nVulnerability CVE-2026-33033\nSeverity: MEDIUM\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-33033](https://avd.aquasec.com/nvd/cve-2026-33033)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: django@5.2.12"
              }
            }
          ]
        },
        {
          "ruleId": "CVE-2026-4277",
          "ruleIndex": 4,
          "level": "note",
          "message": {
            "text": "Package: django\nInstalled Version: 5.2.12\nVulnerability CVE-2026-4277\nSeverity: LOW\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-4277](https://avd.aquasec.com/nvd/cve-2026-4277)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: django@5.2.12"
              }
            }
          ]
        },
        {
          "ruleId": "CVE-2026-4292",
          "ruleIndex": 5,
          "level": "note",
          "message": {
            "text": "Package: django\nInstalled Version: 5.2.12\nVulnerability CVE-2026-4292\nSeverity: LOW\nFixed Version: 6.0.4, 5.2.13, 4.2.30\nLink: [CVE-2026-4292](https://avd.aquasec.com/nvd/cve-2026-4292)"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "poetry.lock",
                  "uriBaseId": "ROOTPATH"
                },
                "region": {
                  "startLine": 1,
                  "startColumn": 1,
                  "endLine": 1,
                  "endColumn": 1
                }
              },
              "message": {
                "text": "poetry.lock: django@5.2.12"
              }
            }
          ]
        }
      ],
      "columnKind": "utf16CodeUnits",
      "originalUriBaseIds": {
        "ROOTPATH": {
          "uri": "file:///"
        }
      }
    }
  ]
}
```

Example of broken markdown (between 2 and 3)

```markdown
### Summary of the vulnerabilities check  


#### **❗You have vulnerabilities in your code**

#### vulnerabilities

|| File | Severity | ID | Package | Installed Version | Fixed Version | Description |
|---|---|---|---|---|---|---|---|
| 1 | [poetry.lock]() | MEDIUM | CVE-2026-39892 | cryptography | 46.0.6 | 46.0.7 | cryptography is a package designed to expose cryptographic primitives and recipes to Python developers. From 45.0.0 to before 46.0.7, if a non-contiguous buffer was passed to APIs which accepted Python buffers (e.g. Hash.update()), this could lead to buffer overflows. This vulnerability is fixed in 46.0.7. |
| 2 | [poetry.lock]() | HIGH | CVE-2026-33034 | django | 5.2.12 | 6.0.4, 5.2.13, 4.2.30 | An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30. ASGI requests with a missing or understated `Content-Length` header could
 bypass the `DATA_UPLOAD_MAX_MEMORY_SIZE` limit when reading
 `HttpRequest.body`, allowing remote attackers to load an unbounded request body into
 memory. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected. Django would like to thank Superior for reporting this issue. |
| 3 | [poetry.lock]() | HIGH | CVE-2026-3902 | django | 5.2.12 | 6.0.4, 5.2.13, 4.2.30 | An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30. `ASGIRequest` allows a remote attacker to spoof headers by exploiting an ambiguous mapping of two header variants (with hyphens or with underscores) to a single version with underscores. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected. Django would like to thank Tarek Nakkouch for reporting this issue. |
| 4 | [poetry.lock]() | MEDIUM | CVE-2026-33033 | django | 5.2.12 | 6.0.4, 5.2.13, 4.2.30 | An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30. `MultiPartParser` allows remote attackers to degrade performance by submitting multipart uploads with `Content-Transfer-Encoding: base64` including excessive whitespace. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected. Django would like to thank Seokchan Yoon for reporting this issue. |
| 5 | [poetry.lock]() | LOW | CVE-2026-4277 | django | 5.2.12 | 6.0.4, 5.2.13, 4.2.30 | An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30. Add permissions on inline model instances were not validated on submission of
 forged `POST` data in `GenericInlineModelAdmin`. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected. Django would like to thank N05ec@LZU-DSLab for reporting this issue. |
| 6 | [poetry.lock]() | LOW | CVE-2026-4292 | django | 5.2.12 | 6.0.4, 5.2.13, 4.2.30 | An issue was discovered in 6.0 before 6.0.4, 5.2 before 5.2.13, and 4.2 before 4.2.30. Admin changelist forms using `ModelAdmin.list_editable` incorrectly allowed new
 instances to be created via forged `POST` data. Earlier, unsupported Django series (such as 5.0.x, 4.1.x, and 3.2.x) were not evaluated and may also be affected. Django would like to thank Cantina for reporting this issue. |
```

[SA3P-22]: https://saritasa.atlassian.net/browse/SA3P-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ