### PR TITLE
feat: get rid of `apt` in the security-audit action

### DIFF
--- a/.github/actions/security-audit/action.yaml
+++ b/.github/actions/security-audit/action.yaml
@@ -36,10 +36,6 @@ inputs:
     description: Trivy version to install
     required: false
     default: "v0.69.2"
-  apt-cache-version:
-    description: Bump this value to reset the apt package cache
-    required: false
-    default: "1.2"
 
 runs:
   using: composite
@@ -59,13 +55,6 @@ runs:
         cache-python: true
         cache-suffix: "security-audit"
         working-directory: ${{github.action_path}}
-
-
-    - name: Install sponge(from moreutils package) for editing data.json in-place
-      uses: awalsh128/cache-apt-pkgs-action@v1
-      with:
-        packages: moreutils
-        version: ${{ inputs.apt-cache-version }}
 
     - name: Install trivy
       uses: aquasecurity/setup-trivy@v0.2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-04-27
+
+[v5.6]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/44)
+- Get rid of `apt` in the security-audit action
+
 ## 2026-03-25
 
 [v5.3]
@@ -10,7 +17,7 @@
 - [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/38)
 - Excluded `CHANGELOG.md` and `README.md` files from PR summary analysis in `pr-summary` action
 - [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/37)
-- Added `client_session_timeout_seconds` for MCP server in `pr-summary` action; 
+- Added `client_session_timeout_seconds` for MCP server in `pr-summary` action;
 - Added code changes size limit with truncation to prevent exceeding model context window
 
 ## 2026-03-20


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Changes:
- eliminate the dependency on `apt` from the `security-audit` action

Related PR:
- https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/265

**Tested in** aamp-magento:
- [Vulnerabilities check](https://github.com/saritasa-nest/aamp-magento/pull/34#issuecomment-4324106928)
- [Secrets check](https://github.com/saritasa-nest/aamp-magento/pull/34#issuecomment-4324107804)

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ