### PR TITLE
feat: update jira step SD-373

### DIFF
--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -41,6 +41,11 @@ inputs:
         terraform-docs=https://github.com/terraform-docs/terraform-docs/releases/download/v0.19.0/terraform-docs-v0.19.0-linux-amd64.tar.gz
         terragrunt=https://github.com/gruntwork-io/terragrunt/releases/download/v0.75.0/terragrunt_linux_amd64
     required: true
+  run-jira-pre-commit:
+    description: |
+      Whether to run Jira Task ID pre-commit hook.
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -153,6 +158,7 @@ runs:
     # Get the commit's message and run Jira `pre-commit` hook on it
     - name: Run jira pre-commit hook
       shell: bash
+      if: inputs.run-jira-pre-commit == 'true'
       run: |
         commit_hash="${{ github.event.pull_request.head.sha }}"
         author="$(git log -1 --format='%an' "$commit_hash")"


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)
- update jira-pre-commit step in the pre-commit action

`jira-pre-commit` hook is configured to always run after all of the `pre-commit` staged hooks in the workflow. 

Currently, in a case, when a repository doesn't have a `jira-pre-commit` hook in the `pre-commit-config` -- the workflow will fail:
<img width="1329" height="324" alt="image" src="https://github.com/user-attachments/assets/d2731cf3-29fc-4420-b4b4-dd74068ef42e" />

After adding an explicit false input to the `pre-commit.yaml`:
```sh
- name: Run pre-commit checks
  uses: saritasa-nest/saritasa-github-actions/.github/actions/pre-commit@feature/update-jira-step
  with:
    run-jira-pre-commit: false
```
the workflow will skip the jira-pre-commit step altogether:
<img width="1474" height="455" alt="image" src="https://github.com/user-attachments/assets/4c32d23e-8de3-4843-8e53-ca870cf66ec6" />

Explanation and case usage for this solution is the https://github.com/saritasa-nest/ai-policy repository, which needs to use pre-commit hooks, but doesn't have a Jira task.

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->


[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ