### PR TITLE
feat: move pre-commit action to uv SD-1362

### DIFF
--- a/.github/actions/pre-commit/README.md
+++ b/.github/actions/pre-commit/README.md
@@ -14,7 +14,7 @@ If the commit/push was made without running local pre-commit checks (e.g. using 
 
 1. Setup:
 
-- Installs Python (with uv), Node.js, and Terraform.
+- Installs Python, uv, Node.js, and Terraform.
 - Installs needed pre-commit tools.
 - Caches tools to speed up future runs.
 

--- a/.github/actions/pre-commit/README.md
+++ b/.github/actions/pre-commit/README.md
@@ -14,7 +14,7 @@ If the commit/push was made without running local pre-commit checks (e.g. using 
 
 1. Setup:
 
-- Installs Python, Node.js, and Terraform.
+- Installs Python (with uv), Node.js, and Terraform.
 - Installs needed pre-commit tools.
 - Caches tools to speed up future runs.
 

--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -7,28 +7,28 @@
   # │   This action is needed to block merges and pushes to `develop` and `main` branches if commits were made without   │
   # │   local pre-commit checks (e.g. commited/pushed using '--no-verify').                                              │
   # │                                                                                                                    │
-  # └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘ 
+  # └────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 name: pre-commit
-description: Action used to run pre-commit checks on the code. All pre-commit hooks are taken from the .pre-commit-config.yaml file. 
+description: Action used to run pre-commit checks on the code. All pre-commit hooks are taken from the .pre-commit-config.yaml file.
 inputs:
   ignore-commit-authors:
     description: |
       Whose commits to skip during Jira Task ID in commit message pre-commit check
       Autocommits made by bots (e.g. tekton-kustomize) usually don't have Jira Task ID in them
-      This input allows us to specify authors whose commit messages should be ignored      
+      This input allows us to specify authors whose commit messages should be ignored
     required: false
     default: tekton-kustomize
   node-version:
     description: |
       Node.js version
-      Node.js is needed for terraform_fmt pre-commit hook (used for formatting Terraform files) to work      
+      Node.js is needed for terraform_fmt pre-commit hook (used for formatting Terraform files) to work
     required: false
     default: '20'
   python-version:
     description: |
       Python version
       Python is needed to install `pre-commit`
-      `pre-commit` is installed via `python -m pip install pre-commit` in the workflow    
+      `pre-commit` is installed via `uv tool install pre-commit --with pre-commit-uv` in the workflow
     required: false
     default: '3.x'
   tools-list:
@@ -50,11 +50,15 @@ inputs:
 runs:
   using: composite
   steps:
-    # Setup Python using the python-version from inputs
-    - name: Setup python
-      uses: actions/setup-python@v5
+
+    - name: Install uv
+      id: setup-uv
+      uses: astral-sh/setup-uv@v7
       with:
-        python-version: ${{ inputs.python-version }}
+        enable-cache: true
+        activate-environment: true
+        working-directory: ${{github.action_path}}
+        # python-version: ${{ inputs.python-version }}
 
     # Get Terraform version, if a `.terraform-version` file exists in the repo
     # Otherwise, use the latest version
@@ -119,12 +123,11 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    # Install pre-commit via python
+    # Install pre-commit via uv
     - name: Install pre-commit
       shell: bash
       run: |
-        python -m pip install pre-commit
-        python -m pip freeze --local
+        uv tool install pre-commit --with pre-commit-uv
 
     # Run `pre-commit` checks (what checks to run are taken from the `.pre-commit-config.yaml`)
     - name: Run pre-commit checks

--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -28,7 +28,7 @@ inputs:
     description: |
       Python version
       Python is needed to install `pre-commit`
-      `pre-commit` is installed via `uv tool install pre-commit --with pre-commit-uv` in the workflow
+      `pre-commit` is installed via `python -m pip install pre-commit` in the workflow
     required: false
     default: '3.x'
   tools-list:
@@ -50,15 +50,17 @@ inputs:
 runs:
   using: composite
   steps:
+    # Setup Python using the python-version from inputs
+    - name: Setup python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
 
     - name: Install uv
       id: setup-uv
       uses: astral-sh/setup-uv@v7
       with:
-        enable-cache: true
-        activate-environment: true
         working-directory: ${{github.action_path}}
-        # python-version: ${{ inputs.python-version }}
 
     # Get Terraform version, if a `.terraform-version` file exists in the repo
     # Otherwise, use the latest version
@@ -123,11 +125,12 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    # Install pre-commit via uv
+    # Install pre-commit via python
     - name: Install pre-commit
       shell: bash
       run: |
-        uv tool install pre-commit --with pre-commit-uv
+        python -m pip install pre-commit
+        python -m pip freeze --local
 
     # Run `pre-commit` checks (what checks to run are taken from the `.pre-commit-config.yaml`)
     - name: Run pre-commit checks


### PR DESCRIPTION
### Summary

Task: [SD-1360](https://saritasa.atlassian.net/browse/SD-1360)

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->

For PR https://github.com/saritasa-nest/saritasa-cloud-kubernetes-aws/pull/182 I added a custom python script as a pre-commit. As we started to do a while ago, I called it with `uv` instead of python.

I have now added `uv` into this action so the pre-commit can complete but I kept the `actions/setup-python@v5` to keep compatibility with older versions.

(as an alternative we can go ahead and delete the `actions/setup-python` and set:

```diff
-    # Install pre-commit via python
+    # Install pre-commit via uv
    - name: Install pre-commit
      shell: bash
      run: |
-        python -m pip install pre-commit
-        python -m pip freeze --local
+        uv tool install pre-commit --with pre-commit-uv
```

but we would need to remove/comment the variable

```yaml
  python-version:
    description: |
      Python version
      Python is needed to install `pre-commit`
      `pre-commit` is installed via `python -m pip install pre-commit` in the workflow
    required: false
    default: '3.x'
```

because the syntax `3.x` is not valid for uv  (by default uv would pick latest python available which is the same as 3.x)

[SD-1360]: https://saritasa.atlassian.net/browse/SD-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ