### PR TITLE
feat: update placeholders to retrieve commit message body SD-373

### DIFF
--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -168,7 +168,8 @@ runs:
       run: |
         commit_hash="${{ github.event.pull_request.head.sha }}"
         author="$(git log -1 --format='%an' "$commit_hash")"
-        commit_msg="$(git log -1 --format='%s' "$commit_hash")"
+        # Get commit message, including the commit body
+        commit_msg="$(git log -1 --format='%B' "$commit_hash")"
 
         # Output commit link and message
         echo "https://github.com/${{ github.repository }}/commit/$commit_hash -- $commit_msg"


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)
- update placeholders to retrieve jira-pre-commit message to use raw body message

Local commit message and hooks:
<img width="1033" height="444" alt="image" src="https://github.com/user-attachments/assets/bf910afa-99f8-4528-b444-e1e02716a278" />

Before update (checking only the commit message, without the body of the commit message):
<img width="954" height="135" alt="image" src="https://github.com/user-attachments/assets/43a283dc-9eb8-43d4-a96e-d8a6fbab3b78" />

After update:
<img width="964" height="134" alt="image" src="https://github.com/user-attachments/assets/dce51cc2-1bc8-462f-a69d-5c37b5fad45b" />

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->


[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ