### PR TITLE
feat: update mcp version, SD-373

### DIFF
--- a/.github/actions/pr-summary/README.md
+++ b/.github/actions/pr-summary/README.md
@@ -11,14 +11,16 @@ A GitHub Action that automatically generates and updates pull request descriptio
 
 ## Inputs
 
-| Input            | Required | Default                          | Description                                    |
-| ---------------- | -------- | -------------------------------- | ---------------------------------------------- |
-| `github-token`   | Yes      | -                                | GitHub token for API access                    |
-| `openai-api-key` | Yes      | -                                | OpenAI API key for PR summary generation       |
-| `pr-number`      | Yes      | -                                | PR number to update with the generated summary |
-| `jira-url`       | No       | `https://saritasa.atlassian.net` | Base URL for JIRA instance                     |
-| `openai-model`   | No       | `gpt-5`                          | OpenAI model to use for summary generation     |
-| `openai-prompt`  | No       | [See below](#prompt-example)     | Custom prompt template for OpenAI              |
+| Input                        | Required | Default                          | Description                                                          |
+| ---------------------------- | -------- | -------------------------------- | -------------------------------------------------------------------- |
+| `github-token`               | Yes      | -                                | GitHub token for API access                                          |
+| `openai-api-key`             | Yes      | -                                | OpenAI API key for PR summary generation                             |
+| `pr-number`                  | Yes      | -                                | PR number to update with the generated summary                       |
+| `jira-url`                   | No       | `https://saritasa.atlassian.net` | Base URL for JIRA instance                                           |
+| `openai-model`               | No       | `gpt-5`                          | OpenAI model to use for summary generation                           |
+| `openai-prompt`              | No       | [See below](#prompt-example)     | Custom prompt template for OpenAI                                    |
+| `mcp-server-git-version`     | No       | `2026.7.10`                      | Version of mcp-server-git to use                                     |
+| `mcp-server-git-constraints` | No       | `mcp>=2`                         | Dependency constraints for mcp-server-git uvx environment            |
 
 ## OpenAI API Key
 

--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -72,6 +72,14 @@ inputs:
       labels:
         - label1
         - label2
+  mcp-server-git-version:
+    description: Version of mcp-server-git to use (e.g. 2026.7.10)
+    required: false
+    default: 2026.7.10
+  mcp-server-git-constraints:
+    description: Dependency constraints for mcp-server-git uvx environment (e.g. mcp<2)
+    required: false
+    default: mcp>=2
   pr-number:
     description: PR number to update with the generated summary
     required: true
@@ -106,6 +114,8 @@ runs:
         REPO_PATH: ${{ github.workspace }}
         REPOSITORY: ${{ github.repository }}
         OPENAI_PROMPT: ${{ inputs.openai-prompt }}
+        MCP_SERVER_GIT_VERSION: ${{ inputs.mcp-server-git-version }}
+        MCP_SERVER_GIT_CONSTRAINTS: ${{ inputs.mcp-server-git-constraints }}
       run: |
         set -euo pipefail
         # sample /tmp/ai_output.yaml:

--- a/.github/actions/pr-summary/pr-summary-generator.py
+++ b/.github/actions/pr-summary/pr-summary-generator.py
@@ -64,6 +64,8 @@ class AgentConfig:
     """
     github_client: Github
     jira_url: str
+    mcp_server_git_constraints: str
+    mcp_server_git_version: str
     model: str
     openai_prompt: str
     pr_number: int
@@ -128,11 +130,13 @@ class PrSummaryAgent:
 
         # uvx may take time to download mcp-server-git.
         # increased timeout prevent flaky McpError: Timed out failures
+        mcp_server_git_pkg = f'mcp-server-git@{self.config.mcp_server_git_version}'
+        uvx_args = ['--with', self.config.mcp_server_git_constraints, mcp_server_git_pkg, '--repository', str(self.config.repo_path)]
         async with MCPServerStdio(
             cache_tools_list=True,
             params={
                 'command': 'uvx',
-                'args': ['mcp-server-git', '--repository', str(self.config.repo_path)],
+                'args': uvx_args,
             },
             client_session_timeout_seconds=30,
         ) as server:
@@ -247,6 +251,8 @@ def main():
     config = AgentConfig(
         github_client=github_client,
         jira_url=args.jira_url,
+        mcp_server_git_constraints=os.environ['MCP_SERVER_GIT_CONSTRAINTS'],
+        mcp_server_git_version=os.environ['MCP_SERVER_GIT_VERSION'],
         model=args.model,
         openai_prompt=os.environ.get('OPENAI_PROMPT'),
         pr_number=args.pr_number,


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

error: https://github.com/saritasa-nest/usummit-infra-aws/actions/runs/30442293054

- Added `mcp-server-git-version` and `mcp-server-git-constraints` workflow inputs to allow overriding mcp-server-git version and dependency constraints (workaround for upstream [issue](https://github.com/modelcontextprotocol/servers/issues/4570))


tested here https://github.com/saritasa-nest/usummit-infra-aws/actions/runs/30446100944/job/90556743263
<img width="1088" height="880" alt="image" src="https://github.com/user-attachments/assets/e76057e6-1bd4-416c-a3d5-f14a277ca359" />


[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ