### PR TITLE
feat: update promt for pr-summary action

### DIFF
--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -58,26 +58,25 @@ inputs:
         value files, or config directories.
       - `c/X` or `c/X/Y`: component label — assign when the PR modifies that component's
         own codebase. A pipeline or CI configuration dedicated to a specific component
-        (e.g. autotests pipeline for android) should also get that component's label.
+        (e.g. autotests pipeline) should also get that component's label.
       - `p/X` or `p/X/Y`: platform label — assign when the PR modifies that platform's
         own codebase.
       - `tooling`: assign for changes to CI/CD workflow files (.github/workflows/),
         .pre-commit configs, or similar dev tooling. Do NOT use `p/github` for these —
         `p/github` is only for changes to the GitHub platform stack (Apps, settings, integrations).
 
-      Key principle: assign a label only if the changed files BELONG to that component
-      or platform. Files that merely reference, import, or create custom resources
-      managed by another platform do not count. Ownership is determined by which team
-      would review the change, not by what technologies the code mentions.
+      CRITICAL: assign a `p/` or `c/` label ONLY when the PR directly modifies that
+      platform/component ITSELF — not when the PR merely USES or REFERENCES it.
 
-      When a more specific label exists (e.g. `p/tekton/build-pipeline` vs `p/tekton`),
-      prefer the more specific one. Do not assign both the generic and specific label.
-      For sub-labels (e.g. `p/tekton/build-pipeline`, `p/tekton/selenium-autotests`),
-      assign one only if the changed files are in that sub-label's own directory.
-      Do NOT pick a sub-label just because its name is textually similar to the PR content.
-      If no sub-label's directory matches exactly, use the closest parent label.
-      Match labels based on the directory or component being changed, not by keyword
-      similarity between the PR content and the label name.
+      Examples of when NOT to assign a label:
+      - Creating a ScaledObject inside another component → do NOT assign `p/keda`
+      - Creating an ArgoCD Application to deploy something → do NOT assign `p/argocd`
+      - Adding a Karpenter NodePool inside a pipeline chart → do NOT assign `p/karpenter`
+      - Referencing Selenium Grid in a test pipeline → do NOT assign `p/selenium-grid`
+      - Referencing Replicator resources → do NOT assign `p/replicator`
+
+      When multiple `p/X/Y` sub-labels exist, assign one only if the changed files are
+      in that sub-label's own directory. Do not pick a sub-label by keyword similarity.
 
       Only include labels that exist exactly in the list above. If no labels match, use an empty list.
 

--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -67,7 +67,7 @@ inputs:
         (IAM roles for GitHub Actions, OIDC federation, GitHub Apps Terraform).
         Do NOT assign `p/github` for workflow or dev tooling changes — those are `tooling`.
 
-      CRITICAL: assign a `p/` or `c/` label ONLY when the PR directly modifies that
+      CRITICAL: assign a p/ or c/ label ONLY when the PR directly modifies that
       platform/component ITSELF — not when the PR merely USES or REFERENCES it.
 
       Examples of when NOT to assign a label:

--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -57,9 +57,13 @@ inputs:
       - `env=X`: pick based on environment indicators — folder names, environment-specific
         value files, or config directories.
       - `c/X` or `c/X/Y`: component label — assign when the PR modifies that component's
-        own codebase.
+        own codebase. A pipeline or CI configuration dedicated to a specific component
+        (e.g. autotests pipeline for android) should also get that component's label.
       - `p/X` or `p/X/Y`: platform label — assign when the PR modifies that platform's
         own codebase.
+      - `tooling`: assign for changes to CI/CD workflow files (.github/workflows/),
+        .pre-commit configs, or similar dev tooling. Do NOT use `p/github` for these —
+        `p/github` is only for changes to the GitHub platform stack (Apps, settings, integrations).
 
       Key principle: assign a label only if the changed files BELONG to that component
       or platform. Files that merely reference, import, or create custom resources
@@ -68,6 +72,12 @@ inputs:
 
       When a more specific label exists (e.g. `p/tekton/build-pipeline` vs `p/tekton`),
       prefer the more specific one. Do not assign both the generic and specific label.
+      For sub-labels (e.g. `p/tekton/build-pipeline`, `p/tekton/selenium-autotests`),
+      assign one only if the changed files are in that sub-label's own directory.
+      Do NOT pick a sub-label just because its name is textually similar to the PR content.
+      If no sub-label's directory matches exactly, use the closest parent label.
+      Match labels based on the directory or component being changed, not by keyword
+      similarity between the PR content and the label name.
 
       Only include labels that exist exactly in the list above. If no labels match, use an empty list.
 

--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -53,16 +53,22 @@ inputs:
 
       Available PR labels (use ONLY these exact values, do not invent new ones): {available_labels}
 
-      Repository structure for label selection:
-      - `envs/dev/`, `envs/prod/`, `envs/staging/` — environment-specific configs
-      - `stacks/apps/<component>/` — application component stacks
-      - `stacks/platforms/<platform>/` — platform/tool stacks (e.g. github, argocd, sentry)
-      - `stacks/aws/<service>/` — AWS service stacks (e.g. ecr, eks, rds)
-
       Label selection rules:
-      - `env=X`: use folder names like `envs/dev/`, `envs/prod/` as a strong signal. Pick the matching label.
-      - `c/X` or `c/X/Y`: component label — analyze the changed files and pick the label that matches the affected application component.
-      - `p/X` or `p/X/Y`: platform label — analyze the changed files and pick the label that matches the platform tool or AWS service being configured.
+      - `env=X`: pick based on environment indicators — folder names, environment-specific
+        value files, or config directories.
+      - `c/X` or `c/X/Y`: component label — assign when the PR modifies that component's
+        own codebase.
+      - `p/X` or `p/X/Y`: platform label — assign when the PR modifies that platform's
+        own codebase.
+
+      Key principle: assign a label only if the changed files BELONG to that component
+      or platform. Files that merely reference, import, or create custom resources
+      managed by another platform do not count. Ownership is determined by which team
+      would review the change, not by what technologies the code mentions.
+
+      When a more specific label exists (e.g. `p/tekton/build-pipeline` vs `p/tekton`),
+      prefer the more specific one. Do not assign both the generic and specific label.
+
       Only include labels that exist exactly in the list above. If no labels match, use an empty list.
 
       Respond ONLY with valid YAML in this exact format, no extra text:

--- a/.github/actions/pr-summary/action.yaml
+++ b/.github/actions/pr-summary/action.yaml
@@ -62,8 +62,10 @@ inputs:
       - `p/X` or `p/X/Y`: platform label — assign when the PR modifies that platform's
         own codebase.
       - `tooling`: assign for changes to CI/CD workflow files (.github/workflows/),
-        .pre-commit configs, or similar dev tooling. Do NOT use `p/github` for these —
-        `p/github` is only for changes to the GitHub platform stack (Apps, settings, integrations).
+        .pre-commit configs, or similar dev tooling files within a repository.
+      - `p/github`: assign when the PR modifies the GitHub platform infrastructure
+        (IAM roles for GitHub Actions, OIDC federation, GitHub Apps Terraform).
+        Do NOT assign `p/github` for workflow or dev tooling changes — those are `tooling`.
 
       CRITICAL: assign a `p/` or `c/` label ONLY when the PR directly modifies that
       platform/component ITSELF — not when the PR merely USES or REFERENCES it.

--- a/.github/actions/pr-summary/pr-summary-generator.py
+++ b/.github/actions/pr-summary/pr-summary-generator.py
@@ -195,10 +195,10 @@ class PrSummaryAgent:
         return ('\n\n' + human_text) if human_text else ''
 
 def get_taggable_labels(repository) -> List[str]:
-    """Return labels with env=, c/, or p/ prefixes from the repository."""
+    """Return labels managed by AI: env=, c/, p/ prefixes and the tooling label."""
     return [
         label.name for label in repository.get_labels()
-        if re.match(r'^(env=|c/|p/)', label.name)
+        if re.match(r'^(env=|c/|p/)', label.name) or label.name == 'tooling'
     ]
 
 def extract_jira_issues(commits: List[Commit]) -> Set[str]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 [v6.2]
 
-- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/48)
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/50)
 - Update prompt for `pr-summary` action
 
 ## 2026-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-10
+
+[v6.1]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/48)
+- Update prompt for `pr-summary` action
+
 ## 2026-03-27
 
 [v5.7]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-07-10
 
-[v6.1]
+[v6.2]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-github-actions/pull/48)
 - Update prompt for `pr-summary` action


### PR DESCRIPTION
### Summary

Task: [SD-1606](https://saritasa.atlassian.net/browse/SD-1606)

Updated prompt for `pr-summary` action

Problem: 
- `pr-summary` doesn't assign labels correctly

Example:
- [PR](https://github.com/saritasa-nest/usummit-kubernetes-aws/pull/772) contains the following labels
<img width="623" height="407" alt="image" src="https://github.com/user-attachments/assets/11bf63d8-26ca-422a-bb0f-a73d0d58d7bc" />

but must contain only 
1. `c/autotests` 
2.  `env=staging`
3. `Needs review`(It's added by another bot, so it's not in the test example, that's okay)

Tested [here](https://github.com/saritasa-nest/test-pr-summary-dasha/pull/11)

[SD-1606]: https://saritasa.atlassian.net/browse/SD-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ